### PR TITLE
First version of the itemsEditable mode.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,12 +8,14 @@ A custom suggest displayer for DBList object properties which adapts the suggest
 * To activate it, you must edit the XClass and set, for the target property, the fields Use suggest and Multiple select to true, and the field Custom display to:
 {{include document="XWiki.SuggestDisplay" /}}
 
-* To activate the itemsEditable mode that allows you to create new items and edit selected items, keep the configuration above and precede the {{include}} macro with below code
-{{velocity}}
+* To activate the itemsEditable mode that allows you to create new items and edit selected items, keep the configuration above and precede the {{include}} macro with below code.
+
+`{{velocity}}
 #set($SuggestDisplay_itemsEditable = true)
-{{/velocity}}
+{{/velocity}}`
 
 * To force the space where the new items will be created to a custom space add the bellow code before the {{include}} macro.
-#set($SuggestDisplay_editModeSpace = "yourSpace")
+
+`#set($SuggestDisplay_editModeSpace = "yourSpace")`
 
 Notice that the default space of new items is the space of the document that calls the displayer-multiselect-suggest. 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 displayer-multiselect-suggest
 =============================
 
-##Descritpion
+##Description
 A custom suggest displayer for DBList object properties which adapts the suggest feature to multiple selection.
 
 ##Usage
@@ -15,7 +15,7 @@ A custom suggest displayer for DBList object properties which adapts the suggest
 #set($SuggestDisplay_itemsEditable = true)
 {{/velocity}}
 ```
-* To force the space where the new items will be created to a custom space add the bellow code before the {{include}} macro.
+* To force the space where the new items will be created to a custom space add the below code before the {{include}} macro.
 
 `#set($SuggestDisplay_editModeSpace = "yourSpace")`
 

--- a/README.md
+++ b/README.md
@@ -10,10 +10,11 @@ A custom suggest displayer for DBList object properties which adapts the suggest
 
 * To activate the itemsEditable mode that allows you to create new items and edit selected items, keep the configuration above and precede the {{include}} macro with below code.
 
-`{{velocity}}
+```
+{{velocity}}
 #set($SuggestDisplay_itemsEditable = true)
-{{/velocity}}`
-
+{{/velocity}}
+```
 * To force the space where the new items will be created to a custom space add the bellow code before the {{include}} macro.
 
 `#set($SuggestDisplay_editModeSpace = "yourSpace")`

--- a/README.md
+++ b/README.md
@@ -1,4 +1,19 @@
 displayer-multiselect-suggest
 =============================
 
+##Descritpion
 A custom suggest displayer for DBList object properties which adapts the suggest feature to multiple selection.
+
+##Usage
+* To activate it, you must edit the XClass and set, for the target property, the fields Use suggest and Multiple select to true, and the field Custom display to:
+{{include document="XWiki.SuggestDisplay" /}}
+
+* To activate the itemsEditable mode that allows you to create new items and edit selected items, keep the configuration above and precede the {{include}} macro with below code
+{{velocity}}
+#set($SuggestDisplay_itemsEditable = true)
+{{/velocity}}
+
+* To force the space where the new items will be created to a custom space add the bellow code before the {{include}} macro.
+#set($SuggestDisplay_editModeSpace = "yourSpace")
+
+Notice that the default space of new items is the space of the document that calls the displayer-multiselect-suggest. 

--- a/README.md
+++ b/README.md
@@ -12,11 +12,11 @@ A custom suggest displayer for DBList object properties which adapts the suggest
 
 ```
 {{velocity}}
-#set($SuggestDisplay_itemsEditable = true)
+#set($SuggestDisplayItemsEditable = true)
 {{/velocity}}
 ```
 * To force the space where the new items will be created to a custom space add the below code before the {{include}} macro.
 
-`#set($SuggestDisplay_editModeSpace = "yourSpace")`
+`#set($SuggestDisplayEditModeSpace = "yourSpace")`
 
 Notice that the default space of new items is the space of the document that calls the displayer-multiselect-suggest. 

--- a/pom.xml
+++ b/pom.xml
@@ -96,4 +96,11 @@
      <url>http://nexus.xwiki.org/nexus/service/local/staging/deploy/maven2/</url>
    </repository>
  </distributionManagement>
+ <dependencies>
+   <dependency>
+     <groupId>org.webjars</groupId>
+     <artifactId>jquery-form</artifactId>
+     <version>3.51</version>
+   </dependency>
+ </dependencies>
 </project>

--- a/src/main/resources/XWiki/SuggestDisplay.xml
+++ b/src/main/resources/XWiki/SuggestDisplay.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
+
 <!--
  * See the NOTICE file distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/main/resources/XWiki/SuggestDisplay.xml
+++ b/src/main/resources/XWiki/SuggestDisplay.xml
@@ -128,7 +128,7 @@
   // TODO: rewrite this using the real suggest picker!
   // -------------------------------
   widgets.SuggestDisplayPicker = Class.create({
-
+  
   initialize: function(element) {
     this.input = element;
     // get the referer input to pass it to the suggest script
@@ -180,6 +180,17 @@
 
     this.prepareList();
     this.input.value = "";
+    
+    //Check if in items editable mode
+    var inEditItemsMode = false;
+    var flag = Element.select($(element).up(0), ".inEditItemsMode");
+    if(flag.length &gt; 0){//In items edit mode
+       inEditItemsMode = true;
+    }
+    //Insert the new entry button
+    if(inEditItemsMode){
+       this.insertNewEntryBtn(element);
+    }
   },
   
   prepareList : function() {
@@ -258,13 +269,47 @@
     img.observe('click', this.removeItem.bindAsEventListener(this));
     li.appendChild(span);
     li.appendChild(hiddenInput);
+    //Add the edit button
+    var editImg = new Element("img",{'src': "$xwiki.getSkinFile('icons/silk/page_white_edit.png')"});
+    editImg.observe('click', this.editItem.bindAsEventListener(this));
+    //Check if in items editable mode
+    var inEditItemsMode = false;
+    var flag = Element.select($(this.list).up(0), ".inEditItemsMode");
+    if(flag.length &gt; 0){//In items edit mode
+       inEditItemsMode = true;
+    }
+    if(inEditItemsMode){//In items edit mode
+       li.appendChild(editImg);
+    }
     li.appendChild(img);
+
     this.list.appendChild(li);
     
     // re-setup the list drag and drop so that the new element can also be moved
     this.setupDragDrop();
   },
-
+  
+  editItem : function(event) {
+    var li = event.findElement('li');
+    var input = li.select("input[type='hidden']");
+    var itemDocRef = input[0].value;
+    //Get item class name and property name
+    require(['jquery'],function($){
+       var className = $("input[type='hidden'][id$='_className']",$(li).parent().parent()).eq(0).val();
+       var propertyName = $("input[type='hidden'][id$='_propertyName']",$(li).parent().parent()).eq(0).val();
+       var editURL = "$xwiki.getURL("XWiki.SuggestDisplayEditItems",'edit','editor=inline&amp;xpage=plain')";
+       editURL = editURL + '&amp;itemDocRef=' + itemDocRef + '&amp;action=editItem' + "&amp;className=" + className + "&amp;propertyName=" + propertyName;
+       //Remove popup old content before showing it
+       $('.xdialog-modal-container').remove();
+       new XWiki.widgets.MyModalPopup({pageURL: editURL});
+    });
+  },
+  insertNewEntryBtn:function(element){
+     require(['jquery'],function($){
+       $( '&lt;input type="button" value="Create New Entry" class="button newEntryBtn"/&gt;' ).insertAfter( $(element) );
+     });
+  },
+  
   removeItem : function(event) {
     var item = event.findElement('li');
     item.remove();
@@ -278,7 +323,6 @@
 });
   return XWiki;
 }(XWiki || {}));</code>
-
     </property>
     <property>
       <name/>
@@ -326,6 +370,22 @@
         <unmodifiable>0</unmodifiable>
         <classType>com.xpn.xwiki.objects.classes.TextAreaClass</classType>
       </code>
+      <contentType>
+        <cache>0</cache>
+        <disabled>0</disabled>
+        <displayType>select</displayType>
+        <multiSelect>0</multiSelect>
+        <name>contentType</name>
+        <number>6</number>
+        <prettyName>Content Type</prettyName>
+        <relationalStorage>0</relationalStorage>
+        <separator> </separator>
+        <separators> ,|</separators>
+        <size>1</size>
+        <unmodifiable>0</unmodifiable>
+        <values>CSS|LESS</values>
+        <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
+      </contentType>
       <name>
         <disabled>0</disabled>
         <name>name</name>
@@ -394,6 +454,9 @@ ul.picker-list .picker-item {
 }</code>
     </property>
     <property>
+      <contentType>CSS</contentType>
+    </property>
+    <property>
       <name>Suggest list css</name>
     </property>
     <property>
@@ -453,6 +516,30 @@ ul.picker-list .picker-item {
     #end
     ## now display the item in edit mode, to have the suggest and all.
     $doc.displayEdit($propertyClass, $prefix, $object)
+
+    ## Save the className and the class property name in hidden picker (In editItemInPopups mode)
+    #if("$!SuggestDisplay_itemsEditable" != "" &amp;&amp; $SuggestDisplay_itemsEditable == true)
+       ## New js/css calls
+       #set($discard = $xwiki.ssx.use("XWiki.SuggestDisplayEditItems"))
+       #set($discard = $xwiki.jsx.use("XWiki.SuggestDisplayEditItems"))
+       #set ($attachmentPickerDocName = 'XWiki.AttachmentSelector')
+       $xwiki.ssx.use($attachmentPickerDocName)
+       $xwiki.jsx.use($attachmentPickerDocName)
+       ## Wysiwyg
+       #set($lazy = false)
+       #wysiwyg_import($lazy)
+       ## Date picker : TODO
+       &lt;input type="hidden" id="${prefix}_className" value="$object.getxWikiClass().getName()"/&gt;
+       &lt;input type="hidden" id="${prefix}_propertyName" value="$name"/&gt;
+       &lt;input type="hidden" id="itemParent" value="$doc.getDocumentReference()"/&gt;
+       #if("$!SuggestDisplay_editModeSpace" != "")
+       &lt;input type="hidden" id="itemSpace" value="$!SuggestDisplay_editModeSpace"/&gt;
+       #else
+       &lt;input type="hidden" id="itemSpace" value="$doc.getSpace()"/&gt;
+       #end
+       &lt;input type="hidden" class="inEditItemsMode" value="1"/&gt;
+    #end
+    
     ## --------------------------------
     ## This multiple suggest feature overwrites simple select suggest
     ## -&gt; call multi suggest for current obj &amp; prop

--- a/src/main/resources/XWiki/SuggestDisplay.xml
+++ b/src/main/resources/XWiki/SuggestDisplay.xml
@@ -271,8 +271,21 @@
         li.appendChild(editImg);
     }
     li.appendChild(img);
-
-    this.list.appendChild(li);
+    
+    if (this.inEditItemsMode($(this.list).up(0))) {
+       if(this.list.getElementsByClassName("newEntryLi").length &gt; 0){
+          var newEntryLi = this.list.getElementsByClassName("newEntryLi")[0];
+          this.list.insertBefore(li,newEntryLi);
+       }
+       else
+       {
+          this.list.appendChild(li);
+       }
+    }
+    else
+    {
+       this.list.appendChild(li);
+    }
     
     // re-setup the list drag and drop so that the new element can also be moved
     this.setupDragDrop();
@@ -301,7 +314,9 @@
   },
   insertNewEntryBtn : function(element) {
      require(['jquery'],function($){
-       $( '&lt;input type="button" value="Create New Entry" class="button newEntryBtn"/&gt;' ).insertAfter( $(element) );
+       // Insert the create new entry icon after the last item of the items selected list
+       var lastSelectedItem = $('ul.picker-list li:last',$(element).parent());
+       $( '&lt;li class="newEntryLi"&gt;&lt;a href="javascript:;" class="newEntryBtn"&gt;$services.icon.renderHTML('add') $services.localization.render('platform.appwithinminutes.appHomePageAddEntryHint')&lt;/a&gt;&lt;/li&gt;' ).insertAfter(lastSelectedItem);
      });
   },
   

--- a/src/main/resources/XWiki/SuggestDisplay.xml
+++ b/src/main/resources/XWiki/SuggestDisplay.xml
@@ -264,7 +264,7 @@
     img.observe('click', this.removeItem.bindAsEventListener(this));
     li.appendChild(span);
     li.appendChild(hiddenInput);
-    //Add the edit button
+    // Add the edit button
     if (this.inEditItemsMode($(this.list).up(0))) {
         var editImg = new Element("img",{'src': "$xwiki.getSkinFile('icons/silk/page_white_edit.png')"});
         editImg.observe('click', this.editItem.bindAsEventListener(this));
@@ -521,7 +521,7 @@ ul.picker-list .picker-item {
        #set($discard = $xwiki.ssx.use($attachmentPickerDocName))
        #set($discard = $xwiki.jsx.use($attachmentPickerDocName))
        ## Wysiwyg
-       #set($lazy = false)
+       #set($lazy = true)
        #wysiwyg_import($lazy)
        ## Date picker : TODO
        &lt;input type="hidden" id="${prefix}_className" value="$object.getxWikiClass().getName()"/&gt;
@@ -533,7 +533,7 @@ ul.picker-list .picker-item {
        &lt;input type="hidden" id="itemSpace" value="$doc.getSpace()"/&gt;
        #end
        &lt;input type="hidden" class="inEditItemsMode" value="1"/&gt;
-       &lt;input type="hidden" class="currentWiki" value="$context.getDatabase()"/&gt;
+       &lt;input type="hidden" class="currentWiki" value="$services.wiki.currentWikiId"/&gt;
     #end
     
     ## --------------------------------

--- a/src/main/resources/XWiki/SuggestDisplay.xml
+++ b/src/main/resources/XWiki/SuggestDisplay.xml
@@ -513,7 +513,7 @@ ul.picker-list .picker-item {
     $doc.displayEdit($propertyClass, $prefix, $object)
 
     ## Save the className and the class property name in hidden picker (In editItemInPopups mode)
-    #if("$!SuggestDisplay_itemsEditable" != '' &amp;&amp; $SuggestDisplay_itemsEditable == true)
+    #if("$!SuggestDisplayItemsEditable" != '' &amp;&amp; $SuggestDisplayItemsEditable == true)
        ## New js/css calls
        #set($discard = $xwiki.ssx.use("XWiki.SuggestDisplayEditItems"))
        #set($discard = $xwiki.jsx.use("XWiki.SuggestDisplayEditItems"))
@@ -527,8 +527,8 @@ ul.picker-list .picker-item {
        &lt;input type="hidden" id="${prefix}_className" value="$object.getxWikiClass().getName()"/&gt;
        &lt;input type="hidden" id="${prefix}_propertyName" value="$name"/&gt;
        &lt;input type="hidden" id="itemParent" value="$doc.getDocumentReference()"/&gt;
-       #if("$!SuggestDisplay_editModeSpace" != "")
-       &lt;input type="hidden" id="itemSpace" value="$!SuggestDisplay_editModeSpace"/&gt;
+       #if("$!SuggestDisplayEditModeSpace" != '')
+       &lt;input type="hidden" id="itemSpace" value="$!SuggestDisplayEditModeSpace"/&gt;
        #else
        &lt;input type="hidden" id="itemSpace" value="$doc.getSpace()"/&gt;
        #end

--- a/src/main/resources/XWiki/SuggestDisplay.xml
+++ b/src/main/resources/XWiki/SuggestDisplay.xml
@@ -182,8 +182,8 @@
     this.prepareList();
     this.input.value = "";
     
-    //Insert the new entry button
-    if(this.inEditItemsMode($(element).up(0))){
+    // Insert the new entry button
+    if (this.inEditItemsMode($(element).up(0))) {
        this.insertNewEntryBtn(element);
     }
   },
@@ -265,7 +265,7 @@
     li.appendChild(span);
     li.appendChild(hiddenInput);
     //Add the edit button
-    if(this.inEditItemsMode($(this.list).up(0))){
+    if (this.inEditItemsMode($(this.list).up(0))) {
         var editImg = new Element("img",{'src': "$xwiki.getSkinFile('icons/silk/page_white_edit.png')"});
         editImg.observe('click', this.editItem.bindAsEventListener(this));
         li.appendChild(editImg);
@@ -278,11 +278,11 @@
     this.setupDragDrop();
   },
 
-  //Check if in items editable mode
-  inEditItemsMode : function(elem){
+  // Check if in items editable mode
+  inEditItemsMode : function(elem) {
     var rep = false;
     var flag = Element.select(elem, ".inEditItemsMode");
-    if(flag.length &gt; 0){//In items edit mode
+    if (flag.length &gt; 0) {//In items edit mode
        rep = true;
     }
     return rep;
@@ -292,19 +292,19 @@
     var li = event.findElement('li');
     var input = li.select("input[type='hidden']");
     var itemDocRef = input[0].value;
-    //Get item class name and property name
-    require(['jquery'],function($){
+    // Get item class name and property name
+    require(['jquery'],function($) {
        var className = $("input[type='hidden'][id$='_className']",$(li).parent().parent()).eq(0).val();
        var propertyName = $("input[type='hidden'][id$='_propertyName']",$(li).parent().parent()).eq(0).val();
        var wiki = $("input[type='hidden'].currentWiki",$(li).parent().parent()).eq(0).val();
        var editURL = "$xwiki.getURL("XWiki.SuggestDisplayEditItems",'view','xpage=plain')";
        editURL = editURL + '&amp;itemDocRef=' + wiki + ':' + itemDocRef + '&amp;action=editItem' + "&amp;className=" + className + "&amp;propertyName=" + propertyName;
-       //Remove popup old content before showing it
+       // Remove popup old content before showing it
        $('.xdialog-modal-container').remove();
        new XWiki.widgets.EditModePopup({pageURL: editURL});
     });
   },
-  insertNewEntryBtn:function(element){
+  insertNewEntryBtn : function(element) {
      require(['jquery'],function($){
        $( '&lt;input type="button" value="Create New Entry" class="button newEntryBtn"/&gt;' ).insertAfter( $(element) );
      });

--- a/src/main/resources/XWiki/SuggestDisplay.xml
+++ b/src/main/resources/XWiki/SuggestDisplay.xml
@@ -181,14 +181,8 @@
     this.prepareList();
     this.input.value = "";
     
-    //Check if in items editable mode
-    var inEditItemsMode = false;
-    var flag = Element.select($(element).up(0), ".inEditItemsMode");
-    if(flag.length &gt; 0){//In items edit mode
-       inEditItemsMode = true;
-    }
     //Insert the new entry button
-    if(inEditItemsMode){
+    if(this.inEditItemsMode($(element).up(0))){
        this.insertNewEntryBtn(element);
     }
   },
@@ -270,16 +264,10 @@
     li.appendChild(span);
     li.appendChild(hiddenInput);
     //Add the edit button
-    var editImg = new Element("img",{'src': "$xwiki.getSkinFile('icons/silk/page_white_edit.png')"});
-    editImg.observe('click', this.editItem.bindAsEventListener(this));
-    //Check if in items editable mode
-    var inEditItemsMode = false;
-    var flag = Element.select($(this.list).up(0), ".inEditItemsMode");
-    if(flag.length &gt; 0){//In items edit mode
-       inEditItemsMode = true;
-    }
-    if(inEditItemsMode){//In items edit mode
-       li.appendChild(editImg);
+    if(this.inEditItemsMode($(this.list).up(0))){
+        var editImg = new Element("img",{'src': "$xwiki.getSkinFile('icons/silk/page_white_edit.png')"});
+        editImg.observe('click', this.editItem.bindAsEventListener(this));
+        li.appendChild(editImg);
     }
     li.appendChild(img);
 
@@ -288,7 +276,17 @@
     // re-setup the list drag and drop so that the new element can also be moved
     this.setupDragDrop();
   },
-  
+
+  //Check if in items editable mode
+  inEditItemsMode : function(elem){
+    var rep = false;
+    var flag = Element.select(elem, ".inEditItemsMode");
+    if(flag.length &gt; 0){//In items edit mode
+       rep = true;
+    }
+    return rep;
+  },
+
   editItem : function(event) {
     var li = event.findElement('li');
     var input = li.select("input[type='hidden']");
@@ -301,7 +299,7 @@
        editURL = editURL + '&amp;itemDocRef=' + itemDocRef + '&amp;action=editItem' + "&amp;className=" + className + "&amp;propertyName=" + propertyName;
        //Remove popup old content before showing it
        $('.xdialog-modal-container').remove();
-       new XWiki.widgets.MyModalPopup({pageURL: editURL});
+       new XWiki.widgets.EditModePopup({pageURL: editURL});
     });
   },
   insertNewEntryBtn:function(element){

--- a/src/main/resources/XWiki/SuggestDisplay.xml
+++ b/src/main/resources/XWiki/SuggestDisplay.xml
@@ -296,8 +296,9 @@
     require(['jquery'],function($){
        var className = $("input[type='hidden'][id$='_className']",$(li).parent().parent()).eq(0).val();
        var propertyName = $("input[type='hidden'][id$='_propertyName']",$(li).parent().parent()).eq(0).val();
+       var wiki = $("input[type='hidden'].currentWiki",$(li).parent().parent()).eq(0).val();
        var editURL = "$xwiki.getURL("XWiki.SuggestDisplayEditItems",'view','xpage=plain')";
-       editURL = editURL + '&amp;itemDocRef=' + itemDocRef + '&amp;action=editItem' + "&amp;className=" + className + "&amp;propertyName=" + propertyName;
+       editURL = editURL + '&amp;itemDocRef=' + wiki + ':' + itemDocRef + '&amp;action=editItem' + "&amp;className=" + className + "&amp;propertyName=" + propertyName;
        //Remove popup old content before showing it
        $('.xdialog-modal-container').remove();
        new XWiki.widgets.EditModePopup({pageURL: editURL});
@@ -537,6 +538,7 @@ ul.picker-list .picker-item {
        &lt;input type="hidden" id="itemSpace" value="$doc.getSpace()"/&gt;
        #end
        &lt;input type="hidden" class="inEditItemsMode" value="1"/&gt;
+       &lt;input type="hidden" class="currentWiki" value="$context.getDatabase()"/&gt;
     #end
     
     ## --------------------------------

--- a/src/main/resources/XWiki/SuggestDisplay.xml
+++ b/src/main/resources/XWiki/SuggestDisplay.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
+
 <!--
  * See the NOTICE file distributed with this work for additional
  * information regarding copyright ownership.
@@ -61,7 +62,7 @@
         <prettyName>Caching policy</prettyName>
         <relationalStorage>0</relationalStorage>
         <separator> </separator>
-        <separators> ,|</separators>
+        <separators>|, </separators>
         <size>1</size>
         <unmodifiable>0</unmodifiable>
         <values>long|short|default|forbid</values>
@@ -106,7 +107,7 @@
         <prettyName>Use this extension</prettyName>
         <relationalStorage>0</relationalStorage>
         <separator> </separator>
-        <separators> ,|</separators>
+        <separators>|, </separators>
         <size>1</size>
         <unmodifiable>0</unmodifiable>
         <values>currentPage|onDemand|always</values>
@@ -295,7 +296,7 @@
     require(['jquery'],function($){
        var className = $("input[type='hidden'][id$='_className']",$(li).parent().parent()).eq(0).val();
        var propertyName = $("input[type='hidden'][id$='_propertyName']",$(li).parent().parent()).eq(0).val();
-       var editURL = "$xwiki.getURL("XWiki.SuggestDisplayEditItems",'edit','editor=inline&amp;xpage=plain')";
+       var editURL = "$xwiki.getURL("XWiki.SuggestDisplayEditItems",'view','xpage=plain')";
        editURL = editURL + '&amp;itemDocRef=' + itemDocRef + '&amp;action=editItem' + "&amp;className=" + className + "&amp;propertyName=" + propertyName;
        //Remove popup old content before showing it
        $('.xdialog-modal-container').remove();
@@ -352,7 +353,7 @@
         <prettyName>Caching policy</prettyName>
         <relationalStorage>0</relationalStorage>
         <separator> </separator>
-        <separators> ,|</separators>
+        <separators>|, </separators>
         <size>1</size>
         <unmodifiable>0</unmodifiable>
         <values>long|short|default|forbid</values>
@@ -378,7 +379,7 @@
         <prettyName>Content Type</prettyName>
         <relationalStorage>0</relationalStorage>
         <separator> </separator>
-        <separators> ,|</separators>
+        <separators>|, </separators>
         <size>1</size>
         <unmodifiable>0</unmodifiable>
         <values>CSS|LESS</values>
@@ -413,7 +414,7 @@
         <prettyName>Use this extension</prettyName>
         <relationalStorage>0</relationalStorage>
         <separator> </separator>
-        <separators> ,|</separators>
+        <separators>|, </separators>
         <size>1</size>
         <unmodifiable>0</unmodifiable>
         <values>currentPage|onDemand|always</values>

--- a/src/main/resources/XWiki/SuggestDisplay.xml
+++ b/src/main/resources/XWiki/SuggestDisplay.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
 <!--
  * See the NOTICE file distributed with this work for additional
  * information regarding copyright ownership.
@@ -280,12 +279,7 @@
 
   // Check if in items editable mode
   inEditItemsMode : function(elem) {
-    var rep = false;
-    var flag = Element.select(elem, ".inEditItemsMode");
-    if (flag.length &gt; 0) {//In items edit mode
-       rep = true;
-    }
-    return rep;
+    return Element.select(elem, '.inEditItemsMode').length &gt; 0;
   },
 
   editItem : function(event) {
@@ -518,13 +512,13 @@ ul.picker-list .picker-item {
     $doc.displayEdit($propertyClass, $prefix, $object)
 
     ## Save the className and the class property name in hidden picker (In editItemInPopups mode)
-    #if("$!SuggestDisplay_itemsEditable" != "" &amp;&amp; $SuggestDisplay_itemsEditable == true)
+    #if("$!SuggestDisplay_itemsEditable" != '' &amp;&amp; $SuggestDisplay_itemsEditable == true)
        ## New js/css calls
        #set($discard = $xwiki.ssx.use("XWiki.SuggestDisplayEditItems"))
        #set($discard = $xwiki.jsx.use("XWiki.SuggestDisplayEditItems"))
-       #set ($attachmentPickerDocName = 'XWiki.AttachmentSelector')
-       $xwiki.ssx.use($attachmentPickerDocName)
-       $xwiki.jsx.use($attachmentPickerDocName)
+       #set($attachmentPickerDocName = 'XWiki.AttachmentSelector')
+       #set($discard = $xwiki.ssx.use($attachmentPickerDocName))
+       #set($discard = $xwiki.jsx.use($attachmentPickerDocName))
        ## Wysiwyg
        #set($lazy = false)
        #wysiwyg_import($lazy)

--- a/src/main/resources/XWiki/SuggestDisplayEditItems.xml
+++ b/src/main/resources/XWiki/SuggestDisplayEditItems.xml
@@ -980,7 +980,10 @@ $.initializeNewEntryBtn();
            {"results":false}
       #else
          #set($documentReference = $services.model.createDocumentReference(null, $request.spaceName, $request.docName))
-         #set($redirectURL = $xwiki.getURL($documentReference,'edit',"template=${request.template}&amp;parent=${request.parent}&amp;title=${request.docName}"))
+         #set($title = $util.encodeURI($request.docName))
+         #set($parent = $util.encodeURI($request.parent))
+         #set($template = $util.encodeURI($request.template))
+         #set($redirectURL = $xwiki.getURL($documentReference,'edit',"template=${template}&amp;parent=${parent}&amp;title=${title}"))
            {"results":"$redirectURL"}
         #end
    #elseif($action == "ajaxUploadAttachment")

--- a/src/main/resources/XWiki/SuggestDisplayEditItems.xml
+++ b/src/main/resources/XWiki/SuggestDisplayEditItems.xml
@@ -637,11 +637,21 @@ initializeItemEditForm : function(itemEditURL,XWModalContent){
       event.preventDefault();
    });
    //Initialize textarea fields Wysiwyg
+   #set($wysiwygConfig = {})
+   #wysiwyg_storeConfig($wysiwygConfig $doc "HOOKID" true)
+   #set($jsVarName = "wysiwygConfig${util.generateRandomString(4)}")
    Wysiwyg.onModuleLoad(function() {
    $("textarea").each(function(){
       var wysiwygConfig = {
-         hookId:$(this).attr("id"),
+         #set($separator = '')
+         #foreach($entry in $wysiwygConfig.entrySet())
+           #if($entry.value || "$!entry.value" != '')
+              ${separator}$entry.key: '$!{escapetool.javascript($entry.value)}'
+              #set($separator = ',')
+           #end
+         #end
       };
+      wysiwygConfig.hookId = $(this).attr("id");
       new WysiwygEditor(wysiwygConfig); 
    });
    });
@@ -759,11 +769,10 @@ initializeAttachmentPicker : function(itemEditURL,attPickerURL,XWModalContent){
 //Save sugggest display item
 saveSuggestDisplayItem : function(XWModalContent){
    var saveURL = $("#editItemForm").attr("action");
-   var formData = $("#editItemForm").serializeObject();
+   var formData = $("#editItemForm").serialize();
    $.ajax({
-	url:saveURL,
-	type:'POST',
-	data:(formData),
+	url:saveURL + "?" + formData,
+	type:'GET',
 	success:function(rep, textStatus, jqXHR){
 	},
 	complete:function(event, XMLHttpRequest, ajaxOptions){

--- a/src/main/resources/XWiki/SuggestDisplayEditItems.xml
+++ b/src/main/resources/XWiki/SuggestDisplayEditItems.xml
@@ -633,6 +633,11 @@ initializeItemEditForm : function(itemEditURL,XWModalContent){
    //Initialize attachment-picker fields
    $(".attachment-picker-start").click(function(event){
       var attPickerURL = $(this).attr("href") + "&amp;xpage=plain";
+      var wikiName = $("#wikiName").val();
+      attPickerURL = attPickerURL + "&amp;wikiName=" + wikiName;
+      if(attPickerURL.indexOf('docname=' + wikiName + ":") == -1){
+         attPickerURL = attPickerURL.replace('docname=','docname=' + wikiName + ':');
+      }
       $.initializeAttachmentPicker(itemEditURL,attPickerURL,XWModalContent);
       event.preventDefault();
    });
@@ -945,6 +950,7 @@ $.initializeNewEntryBtn();
        #set($propertyName = $request.propertyName)
        #getItemClassName($className,$propertyName)
        #set($doc = $xwiki.getDocument($itemDocRef))
+       #set($wikiName = $doc.getDocumentReference().getWikiReference().getName())
        #if($itemClassName != "" &amp;&amp; $xwiki.exists($itemClassName))
           #set($itemClassSheet = $itemClassName.substring(0,$itemClassName.indexOf('Class')))
           #set($itemClassSheet = "${itemClassSheet}Sheet")
@@ -957,6 +963,7 @@ $.initializeNewEntryBtn();
           {{html wiki="true"}}
           &lt;form action="$xwiki.getURL($itemDocRef,'save')" id="editItemForm"&gt;
             {{include reference="$itemClassSheet"/}}
+             &lt;input type="hidden" id="wikiName" value="$wikiName"/&gt;
              &lt;input type="hidden" name="form_token" value="$!{services.csrf.getToken()}" /&gt;
              &lt;input type="hidden" name="xredirect" value="" /&gt;
              &lt;input class="btn btn-primary" type="button" name="action_save" title="Alt+Shift+S" value="Save"&gt;

--- a/src/main/resources/XWiki/SuggestDisplayEditItems.xml
+++ b/src/main/resources/XWiki/SuggestDisplayEditItems.xml
@@ -266,205 +266,19 @@ XWiki.widgets.EditModePopup = Class.create(XWiki.widgets.ModalPopup, {
       <cache>long</cache>
     </property>
     <property>
-      <code>/**
-*   jQuery Ajax File Uploader Version 2.1
-*   jQuery plugin for file upload (http://www.phpletter.com/Our-Projects/AjaxFileUpload/)
-*/
-
-require(['jquery'],function($){
-$.extend({
-	createUploadIframe: function(id, uri){
-		//create frame
-		var frameId = 'jUploadFrame' + id;
-		var iframeHtml = '&lt;iframe id="' + frameId + '" name="' + frameId + '" style="position:absolute; top:-9999px; left:-9999px"';
-		if(window.ActiveXObject){
-			if(typeof uri== 'boolean'){
-				iframeHtml += ' src="' + 'javascript:false' + '"';
-			}
-			else if(typeof uri== 'string'){
-				iframeHtml += ' src="' + uri + '"';
-			}	
-		}
-		iframeHtml += ' /&gt;';
-		$(iframeHtml).appendTo(document.body);
-		return $('#' + frameId).get(0);			
-    },
-    createUploadForm: function(id, fileElementId, data){
-		//create form	
-		var formId = 'jUploadForm' + id;
-		var fileId = 'jUploadFile' + id;
-		var form = $('&lt;form  action="" method="POST" name="' + formId + '" id="' + formId + '" enctype="multipart/form-data"&gt;&lt;/form&gt;');	
-		if(data){
-			for(var i in data)
-			{
-				$('&lt;input type="hidden" name="' + i + '" value="' + data[i] + '" /&gt;').appendTo(form);
-			}			
-		}		
-		var oldElement = $('#' + fileElementId);
-		var newElement = $(oldElement).clone();
-		$(oldElement).attr('id', fileId);
-		$(oldElement).before(newElement);
-		$(oldElement).appendTo(form);
-		
-		//set attributes
-		$(form).css('position', 'absolute');
-		$(form).css('top', '-1200px');
-		$(form).css('left', '-1200px');
-		$(form).appendTo('body');		
-		return form;
-    },
-	ajaxFileUpload: function(s) {
-        // TODO introduce global settings, allowing the client to modify them for all requests, not only timeout		
-        s = $.extend({}, $.ajaxSettings, s);
-        var id = new Date().getTime()        
-		var form = $.createUploadForm(id, s.fileElementId, (typeof(s.data)=='undefined'?false:s.data));
-		var io = $.createUploadIframe(id, s.secureuri);
-		var frameId = 'jUploadFrame' + id;
-		var formId = 'jUploadForm' + id;		
-        // Watch for a new set of requests
-        if ( s.global &amp;&amp; ! $.active++ ){
-			$.event.trigger( "ajaxStart" );
-		}            
-        var requestDone = false;
-        // Create the request object
-        var xml = {}   
-        if ( s.global )
-			$.event.trigger("ajaxSend", [xml, s]);
-        // Wait for a response to come back
-        var uploadCallback = function(isTimeout){			
-			var io = document.getElementById(frameId);
-            try {				
-				if(io.contentWindow){
-					 xml.responseText = io.contentWindow.document.body?io.contentWindow.document.body.innerHTML:null;
-                	 xml.responseXML = io.contentWindow.document.XMLDocument?io.contentWindow.document.XMLDocument:io.contentWindow.document;
-					 
-				}
-				else if(io.contentDocument){
-					xml.responseText = io.contentDocument.document.body?io.contentDocument.document.body.innerHTML:null;
-                	xml.responseXML = io.contentDocument.document.XMLDocument?io.contentDocument.document.XMLDocument:io.contentDocument.document;
-				}						
-            }catch(e){
-				$.handleError(s, xml, null, e);
-			}
-            if ( xml || isTimeout == "timeout") 
-			{				
-                requestDone = true;
-                var status;
-                try {
-                    status = isTimeout != "timeout" ? "success" : "error";
-                    // Make sure that the request was successful or notmodified
-                    if ( status != "error" ){
-                        // process the data (runs the xml through httpData regardless of callback)
-                        var data = $.uploadHttpData( xml, s.dataType );    
-                        // If a local callback was specified, fire it and pass it the data
-                        if ( s.success )
-                            s.success( data, status );
-    
-                        // Fire the global callback
-                        if( s.global )
-                            $.event.trigger( "ajaxSuccess", [xml, s] );
-                    } else
-                        $.handleError(s, xml, status);
-                } catch(e) 
-				{
-                    status = "error";
-                    $.handleError(s, xml, status, e);
-                }
-
-                // The request was completed
-                if( s.global )
-                    $.event.trigger( "ajaxComplete", [xml, s] );
-
-                // Handle the global AJAX counter
-                if ( s.global &amp;&amp; ! --$.active )
-                    $.event.trigger( "ajaxStop" );
-
-                // Process result
-                if ( s.complete )
-                    s.complete(xml, status);
-
-                $(io).unbind()
-
-                setTimeout(function()
-									{	try 
-										{
-											$(io).remove();
-											$(form).remove();	
-											
-										} catch(e) 
-										{
-											$.handleError(s, xml, null, e);
-										}									
-
-									}, 100)
-                xml = null
-
-            }
-        }
-        // Timeout checker
-        if ( s.timeout &gt; 0 ) 
-		{
-            setTimeout(function(){
-                // Check to see if the request is still happening
-                if( !requestDone ) uploadCallback( "timeout" );
-            }, s.timeout);
-        }
-        try 
-		{
-			var form = $('#' + formId);
-			$(form).attr('action', s.url);
-			$(form).attr('method', 'POST');
-			$(form).attr('target', frameId);
-            if(form.encoding)
-			{
-				$(form).attr('encoding', 'multipart/form-data');      			
-            }
-            else
-			{	
-				$(form).attr('enctype', 'multipart/form-data');			
-            }			
-            $(form).submit();
-
-        } catch(e) 
-		{			
-            $.handleError(s, xml, null, e);
-        }
-		$('#' + frameId).load(uploadCallback);
-        return {abort: function () {}};	
-	},
-	uploadHttpData: function( r, type ) {
-        var data = !type;
-        data = type == "xml" || data ? r.responseXML : r.responseText;
-        // If the type is "script", eval it in global context
-        if ( type == "script" )
-            $.globalEval( data );
-        // Get the JavaScript object, if JSON is used.
-        if ( type == "json" )
-            eval( "data = " + data );
-        // evaluate scripts within html
-        if ( type == "html" )
-            $("&lt;div&gt;").html(data).evalScripts();
-		return data;
-    },
-handleError: function( s, xhr, status, e ) {
-    // If a local callback was specified, fire it
-    if ( s.error ) {
-        s.error.call( s.context || window, xhr, status, e );
-    }
-
-    // Fire the global callback
-    if ( s.global ) {
-        (s.context ? jQuery(s.context) : jQuery.event).trigger( "ajaxError", [xhr, s, e] );
-    }
-}
-})
+      <code>document.observe('xwiki:dom:loading', function() {
+// Configure require.js to use jquery-form (https://github.com/malsup/form)
+require.config({
+   "paths": { "jquery-form": "$services.webjars.url('jquery-form/3.52-SNAPSHOT/jquery.form.js')" },
+   "shim": { "jquery-form": [ "jquery" ] }
+    });
 });</code>
     </property>
     <property>
-      <name>jQuery Ajax File Uploader Version 2.1</name>
+      <name>jquery-form plugin</name>
     </property>
     <property>
-      <parse/>
+      <parse>1</parse>
     </property>
     <property>
       <use>onDemand</use>
@@ -706,24 +520,15 @@ initializeAttachmentPicker : function(itemEditURL,attPickerURL,XWModalContent) {
                new XWiki.widgets.Notification("$services.localization.render('xe.attachmentSelector.upload.error.badExtension')", 'error');
            }
            else{
-               var uploadURL = $("#uploadAttachment").attr('action');
-               var params = $("#uploadAttachment :not(input[name='xredirect'])").serialize();
-               var xredirect = "$util.encodeURI($xwiki.getURL('XWiki.SuggestDisplayEditItems','view','xpage=plain&amp;outputSyntax=plain&amp;action=ajaxUploadAttachment'))";
-               uploadURL = uploadURL + "?" + params + "&amp;xredirect=" + xredirect;
                new XWiki.widgets.Notification("$services.localization.render('xe.attachmentSelector.upload.inProgress')", 'inprogress');
-               jQuery.ajaxFileUpload({
-                  url: uploadURL,
-	          secureuri: false,
-   	          fileElementId: 'attachfile',
-	          success: function (data, status) {
-                  },
-                  complete: function(data, status) {
-                      // Reload the page after upload
-                      $(".xnotification-inprogress").remove();
-                      $.initializeAttachmentPicker(itemEditURL,attPickerURL,XWModalContent);
-                  },
-                  error: function (data, status, e) {
-	          }
+               require(['jquery-form'],function(jqf) {
+                  $('#uploadAttachment').ajaxSubmit({
+                     success: function(){
+                        // Reload the page after upload
+                        $(".xnotification-inprogress").remove();
+                        $.initializeAttachmentPicker(itemEditURL,attPickerURL,XWModalContent);  
+                     }
+                  });
                });
              }  
            }
@@ -1019,8 +824,6 @@ $.initializeNewEntryBtn();
          #set($redirectURL = $xwiki.getURL($documentReference,'edit',"template=${template}&amp;parent=${parent}&amp;title=${title}"))
            {"results":"$redirectURL"}
         #end
-   #elseif($action == "ajaxUploadAttachment")
-       {"results":true}
    #end
 #end
 {{/velocity}}</content>

--- a/src/main/resources/XWiki/SuggestDisplayEditItems.xml
+++ b/src/main/resources/XWiki/SuggestDisplayEditItems.xml
@@ -1,0 +1,992 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+-->
+
+<xwikidoc>
+  <web>XWiki</web>
+  <name>SuggestDisplayEditItems</name>
+  <language/>
+  <defaultLanguage/>
+  <translation>0</translation>
+  <parent>XWiki.WebHome</parent>
+  <creator>xwiki:XWiki.Admin</creator>
+  <author>xwiki:XWiki.Admin</author>
+  <customClass/>
+  <contentAuthor>xwiki:XWiki.Admin</contentAuthor>
+  <creationDate>1425480288000</creationDate>
+  <date>1426150490000</date>
+  <contentUpdateDate>1426150271000</contentUpdateDate>
+  <version>1.1</version>
+  <title>SuggestDisplayEditItems</title>
+  <defaultTemplate/>
+  <validationScript/>
+  <comment/>
+  <minorEdit>false</minorEdit>
+  <syntaxId>xwiki/2.1</syntaxId>
+  <hidden>false</hidden>
+  <object>
+    <class>
+      <name>XWiki.JavaScriptExtension</name>
+      <customClass/>
+      <customMapping/>
+      <defaultViewSheet/>
+      <defaultEditSheet/>
+      <defaultWeb/>
+      <nameField/>
+      <validationScript/>
+      <cache>
+        <cache>0</cache>
+        <disabled>0</disabled>
+        <displayType>select</displayType>
+        <multiSelect>0</multiSelect>
+        <name>cache</name>
+        <number>5</number>
+        <prettyName>Caching policy</prettyName>
+        <relationalStorage>0</relationalStorage>
+        <separator> </separator>
+        <separators> ,|</separators>
+        <size>1</size>
+        <unmodifiable>0</unmodifiable>
+        <values>long|short|default|forbid</values>
+        <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
+      </cache>
+      <code>
+        <disabled>0</disabled>
+        <name>code</name>
+        <number>2</number>
+        <prettyName>Code</prettyName>
+        <rows>20</rows>
+        <size>50</size>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.TextAreaClass</classType>
+      </code>
+      <name>
+        <disabled>0</disabled>
+        <name>name</name>
+        <number>1</number>
+        <prettyName>Name</prettyName>
+        <size>30</size>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
+      </name>
+      <parse>
+        <disabled>0</disabled>
+        <displayFormType>select</displayFormType>
+        <displayType>yesno</displayType>
+        <name>parse</name>
+        <number>4</number>
+        <prettyName>Parse content</prettyName>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.BooleanClass</classType>
+      </parse>
+      <use>
+        <cache>0</cache>
+        <disabled>0</disabled>
+        <displayType>select</displayType>
+        <multiSelect>0</multiSelect>
+        <name>use</name>
+        <number>3</number>
+        <prettyName>Use this extension</prettyName>
+        <relationalStorage>0</relationalStorage>
+        <separator> </separator>
+        <separators> ,|</separators>
+        <size>1</size>
+        <unmodifiable>0</unmodifiable>
+        <values>currentPage|onDemand|always</values>
+        <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
+      </use>
+    </class>
+    <name>XWiki.SuggestDisplayEditItems</name>
+    <number>0</number>
+    <className>XWiki.JavaScriptExtension</className>
+    <guid>c25c0c80-67dc-480a-ab8f-db047209ad14</guid>
+    <property>
+      <cache>long</cache>
+    </property>
+    <property>
+      <code>// Make sure the XWiki 'namespace' and the ModalPopup class exist.
+if(typeof(XWiki) == "undefined" || typeof(XWiki.widgets) == "undefined" || typeof(XWiki.widgets.ModalPopup) == "undefined") {
+ if (typeof console != "undefined" &amp;&amp; typeof console.warn == "function") {
+    console.warn("[MessageBox widget] Required class missing: XWiki.widgets.ModalPopup");
+  }
+} else {
+
+XWiki.widgets.MyModalPopup = Class.create(XWiki.widgets.ModalPopup, {
+ /** Default parameters can be added to the custom class. */
+  defaultInteractionParameters : {
+  },
+ /** Constructor. Registers the key listener that pops up the dialog. */
+  initialize : function($super, interactionParameters) {
+   this.interactionParameters = Object.extend(Object.clone(this.defaultInteractionParameters), interactionParameters || {});
+    // call constructor from ModalPopup with params content, shortcuts, options
+    $super(
+     this.createContent(this.interactionParameters),
+      {
+       "show"  : { method : this.showDialog,  keys : [] },
+       "close" : { method : this.closeDialog, keys : ['Esc'] }
+      },
+      {
+         displayCloseButton : true, 
+         verticalPosition : "top",
+         backgroundColor : "#FFF"
+      }
+    );
+   this.showDialog();
+   this.setClass("my-modal-popup");
+  },
+ /** Get the content of the modal dialog using ajax */
+  createContent : function (data) {
+    var content =  new Element('div', {'class': 'modal-popup'});
+    // get page content for the pageURL
+    new Ajax.Request(data.pageURL,
+    {
+      method:'get',
+      onSuccess: function(transport){
+        var response = transport.responseText || "no response text";
+        content.insert(response);
+        require(['jquery'],function($){
+           var itemEditURL = data.pageURL;
+           $.initializeItemEditForm(itemEditURL,content);
+           $.checkItemExists(content);
+        });
+      },
+      onFailure: function(){ content.insert('Something went wrong...'); 
+    }
+    });
+
+    return content;
+  }
+});
+} // if the parent widget is defined</code>
+    </property>
+    <property>
+      <name>Use XWiki Modal Popup</name>
+    </property>
+    <property>
+      <parse>1</parse>
+    </property>
+    <property>
+      <use>onDemand</use>
+    </property>
+  </object>
+  <object>
+    <class>
+      <name>XWiki.JavaScriptExtension</name>
+      <customClass/>
+      <customMapping/>
+      <defaultViewSheet/>
+      <defaultEditSheet/>
+      <defaultWeb/>
+      <nameField/>
+      <validationScript/>
+      <cache>
+        <cache>0</cache>
+        <disabled>0</disabled>
+        <displayType>select</displayType>
+        <multiSelect>0</multiSelect>
+        <name>cache</name>
+        <number>5</number>
+        <prettyName>Caching policy</prettyName>
+        <relationalStorage>0</relationalStorage>
+        <separator> </separator>
+        <separators> ,|</separators>
+        <size>1</size>
+        <unmodifiable>0</unmodifiable>
+        <values>long|short|default|forbid</values>
+        <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
+      </cache>
+      <code>
+        <disabled>0</disabled>
+        <name>code</name>
+        <number>2</number>
+        <prettyName>Code</prettyName>
+        <rows>20</rows>
+        <size>50</size>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.TextAreaClass</classType>
+      </code>
+      <name>
+        <disabled>0</disabled>
+        <name>name</name>
+        <number>1</number>
+        <prettyName>Name</prettyName>
+        <size>30</size>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
+      </name>
+      <parse>
+        <disabled>0</disabled>
+        <displayFormType>select</displayFormType>
+        <displayType>yesno</displayType>
+        <name>parse</name>
+        <number>4</number>
+        <prettyName>Parse content</prettyName>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.BooleanClass</classType>
+      </parse>
+      <use>
+        <cache>0</cache>
+        <disabled>0</disabled>
+        <displayType>select</displayType>
+        <multiSelect>0</multiSelect>
+        <name>use</name>
+        <number>3</number>
+        <prettyName>Use this extension</prettyName>
+        <relationalStorage>0</relationalStorage>
+        <separator> </separator>
+        <separators> ,|</separators>
+        <size>1</size>
+        <unmodifiable>0</unmodifiable>
+        <values>currentPage|onDemand|always</values>
+        <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
+      </use>
+    </class>
+    <name>XWiki.SuggestDisplayEditItems</name>
+    <number>1</number>
+    <className>XWiki.JavaScriptExtension</className>
+    <guid>6afc2baf-1884-49fa-a64f-94053bc12537</guid>
+    <property>
+      <cache>long</cache>
+    </property>
+    <property>
+      <code>require(['jquery'],function($){
+//var j = $.noConflict();
+$.extend({
+	createUploadIframe: function(id, uri){
+		//create frame
+		var frameId = 'jUploadFrame' + id;
+		var iframeHtml = '&lt;iframe id="' + frameId + '" name="' + frameId + '" style="position:absolute; top:-9999px; left:-9999px"';
+		if(window.ActiveXObject){
+			if(typeof uri== 'boolean'){
+				iframeHtml += ' src="' + 'javascript:false' + '"';
+			}
+			else if(typeof uri== 'string'){
+				iframeHtml += ' src="' + uri + '"';
+			}	
+		}
+		iframeHtml += ' /&gt;';
+		$(iframeHtml).appendTo(document.body);
+		return $('#' + frameId).get(0);			
+    },
+    createUploadForm: function(id, fileElementId, data){
+		//create form	
+		var formId = 'jUploadForm' + id;
+		var fileId = 'jUploadFile' + id;
+		var form = $('&lt;form  action="" method="POST" name="' + formId + '" id="' + formId + '" enctype="multipart/form-data"&gt;&lt;/form&gt;');	
+		if(data){
+			for(var i in data)
+			{
+				$('&lt;input type="hidden" name="' + i + '" value="' + data[i] + '" /&gt;').appendTo(form);
+			}			
+		}		
+		var oldElement = $('#' + fileElementId);
+		var newElement = $(oldElement).clone();
+		$(oldElement).attr('id', fileId);
+		$(oldElement).before(newElement);
+		$(oldElement).appendTo(form);
+		
+		//set attributes
+		$(form).css('position', 'absolute');
+		$(form).css('top', '-1200px');
+		$(form).css('left', '-1200px');
+		$(form).appendTo('body');		
+		return form;
+    },
+	ajaxFileUpload: function(s) {
+        // TODO introduce global settings, allowing the client to modify them for all requests, not only timeout		
+        s = $.extend({}, $.ajaxSettings, s);
+        var id = new Date().getTime()        
+		var form = $.createUploadForm(id, s.fileElementId, (typeof(s.data)=='undefined'?false:s.data));
+		var io = $.createUploadIframe(id, s.secureuri);
+		var frameId = 'jUploadFrame' + id;
+		var formId = 'jUploadForm' + id;		
+        // Watch for a new set of requests
+        if ( s.global &amp;&amp; ! $.active++ ){
+			$.event.trigger( "ajaxStart" );
+		}            
+        var requestDone = false;
+        // Create the request object
+        var xml = {}   
+        if ( s.global )
+			$.event.trigger("ajaxSend", [xml, s]);
+        // Wait for a response to come back
+        var uploadCallback = function(isTimeout){			
+			var io = document.getElementById(frameId);
+            try {				
+				if(io.contentWindow){
+					 xml.responseText = io.contentWindow.document.body?io.contentWindow.document.body.innerHTML:null;
+                	 xml.responseXML = io.contentWindow.document.XMLDocument?io.contentWindow.document.XMLDocument:io.contentWindow.document;
+					 
+				}
+				else if(io.contentDocument){
+					xml.responseText = io.contentDocument.document.body?io.contentDocument.document.body.innerHTML:null;
+                	xml.responseXML = io.contentDocument.document.XMLDocument?io.contentDocument.document.XMLDocument:io.contentDocument.document;
+				}						
+            }catch(e){
+				$.handleError(s, xml, null, e);
+			}
+            if ( xml || isTimeout == "timeout") 
+			{				
+                requestDone = true;
+                var status;
+                try {
+                    status = isTimeout != "timeout" ? "success" : "error";
+                    // Make sure that the request was successful or notmodified
+                    if ( status != "error" ){
+                        // process the data (runs the xml through httpData regardless of callback)
+                        var data = $.uploadHttpData( xml, s.dataType );    
+                        // If a local callback was specified, fire it and pass it the data
+                        if ( s.success )
+                            s.success( data, status );
+    
+                        // Fire the global callback
+                        if( s.global )
+                            $.event.trigger( "ajaxSuccess", [xml, s] );
+                    } else
+                        $.handleError(s, xml, status);
+                } catch(e) 
+				{
+                    status = "error";
+                    $.handleError(s, xml, status, e);
+                }
+
+                // The request was completed
+                if( s.global )
+                    $.event.trigger( "ajaxComplete", [xml, s] );
+
+                // Handle the global AJAX counter
+                if ( s.global &amp;&amp; ! --$.active )
+                    $.event.trigger( "ajaxStop" );
+
+                // Process result
+                if ( s.complete )
+                    s.complete(xml, status);
+
+                $(io).unbind()
+
+                setTimeout(function()
+									{	try 
+										{
+											$(io).remove();
+											$(form).remove();	
+											
+										} catch(e) 
+										{
+											$.handleError(s, xml, null, e);
+										}									
+
+									}, 100)
+                xml = null
+
+            }
+        }
+        // Timeout checker
+        if ( s.timeout &gt; 0 ) 
+		{
+            setTimeout(function(){
+                // Check to see if the request is still happening
+                if( !requestDone ) uploadCallback( "timeout" );
+            }, s.timeout);
+        }
+        try 
+		{
+			var form = $('#' + formId);
+			$(form).attr('action', s.url);
+			$(form).attr('method', 'POST');
+			$(form).attr('target', frameId);
+            if(form.encoding)
+			{
+				$(form).attr('encoding', 'multipart/form-data');      			
+            }
+            else
+			{	
+				$(form).attr('enctype', 'multipart/form-data');			
+            }			
+            $(form).submit();
+
+        } catch(e) 
+		{			
+            $.handleError(s, xml, null, e);
+        }
+		$('#' + frameId).load(uploadCallback);
+        return {abort: function () {}};	
+	},
+	uploadHttpData: function( r, type ) {
+        var data = !type;
+        data = type == "xml" || data ? r.responseXML : r.responseText;
+        // If the type is "script", eval it in global context
+        if ( type == "script" )
+            $.globalEval( data );
+        // Get the JavaScript object, if JSON is used.
+        if ( type == "json" )
+            eval( "data = " + data );
+        // evaluate scripts within html
+        if ( type == "html" )
+            $("&lt;div&gt;").html(data).evalScripts();
+		return data;
+    },
+handleError: function( s, xhr, status, e ) {
+    // If a local callback was specified, fire it
+    if ( s.error ) {
+        s.error.call( s.context || window, xhr, status, e );
+    }
+
+    // Fire the global callback
+    if ( s.global ) {
+        (s.context ? jQuery(s.context) : jQuery.event).trigger( "ajaxError", [xhr, s, e] );
+    }
+}
+})
+});</code>
+    </property>
+    <property>
+      <name>jQuery Ajax File Uploader Version 2.1</name>
+    </property>
+    <property>
+      <parse/>
+    </property>
+    <property>
+      <use>onDemand</use>
+    </property>
+  </object>
+  <object>
+    <class>
+      <name>XWiki.JavaScriptExtension</name>
+      <customClass/>
+      <customMapping/>
+      <defaultViewSheet/>
+      <defaultEditSheet/>
+      <defaultWeb/>
+      <nameField/>
+      <validationScript/>
+      <cache>
+        <cache>0</cache>
+        <disabled>0</disabled>
+        <displayType>select</displayType>
+        <multiSelect>0</multiSelect>
+        <name>cache</name>
+        <number>5</number>
+        <prettyName>Caching policy</prettyName>
+        <relationalStorage>0</relationalStorage>
+        <separator> </separator>
+        <separators> ,|</separators>
+        <size>1</size>
+        <unmodifiable>0</unmodifiable>
+        <values>long|short|default|forbid</values>
+        <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
+      </cache>
+      <code>
+        <disabled>0</disabled>
+        <name>code</name>
+        <number>2</number>
+        <prettyName>Code</prettyName>
+        <rows>20</rows>
+        <size>50</size>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.TextAreaClass</classType>
+      </code>
+      <name>
+        <disabled>0</disabled>
+        <name>name</name>
+        <number>1</number>
+        <prettyName>Name</prettyName>
+        <size>30</size>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
+      </name>
+      <parse>
+        <disabled>0</disabled>
+        <displayFormType>select</displayFormType>
+        <displayType>yesno</displayType>
+        <name>parse</name>
+        <number>4</number>
+        <prettyName>Parse content</prettyName>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.BooleanClass</classType>
+      </parse>
+      <use>
+        <cache>0</cache>
+        <disabled>0</disabled>
+        <displayType>select</displayType>
+        <multiSelect>0</multiSelect>
+        <name>use</name>
+        <number>3</number>
+        <prettyName>Use this extension</prettyName>
+        <relationalStorage>0</relationalStorage>
+        <separator> </separator>
+        <separators> ,|</separators>
+        <size>1</size>
+        <unmodifiable>0</unmodifiable>
+        <values>currentPage|onDemand|always</values>
+        <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
+      </use>
+    </class>
+    <name>XWiki.SuggestDisplayEditItems</name>
+    <number>2</number>
+    <className>XWiki.JavaScriptExtension</className>
+    <guid>d536d42d-2fee-4d9d-98b1-f9aa342c77be</guid>
+    <property>
+      <cache>long</cache>
+    </property>
+    <property>
+      <code>require(['jquery'],function($){
+$.fn.serializeObject = function()
+{
+    var o = {};
+    var a = this.serializeArray();
+    $.each(a, function() {
+        if (o[this.name] !== undefined) {
+            if (!o[this.name].push) {
+                o[this.name] = [o[this.name]];
+            }
+            o[this.name].push(this.value || '');
+        } else {
+            o[this.name] = this.value || '';
+        }
+    });
+    return o;
+};
+
+$.extend({
+//Method to initialize the new item btn
+initializeNewEntryBtn : function(){
+   $("body").on("click",".newEntryBtn",function(event){
+      var index = $(".newEntryBtn").index($(this));
+      var className = $("input[type='hidden'][id$='_className']").eq(index).val();
+      var propertyName = $("input[type='hidden'][id$='_propertyName']").eq(index).val();
+      var itemParent = $("#itemParent").eq(0).val();
+      var itemSpace = $("#itemSpace").eq(0).val();
+      //Open XWiki Modal
+      var newItemURL = "$xwiki.getURL("XWiki.SuggestDisplayEditItems",'edit','editor=inline&amp;xpage=plain')";
+      newItemURL = newItemURL + '&amp;action=newItem' + "&amp;className=" + className + "&amp;propertyName=" + propertyName + "&amp;parent=" + itemParent + "&amp;space=" + itemSpace;
+      $('.xdialog-modal-container').remove();
+      new XWiki.widgets.MyModalPopup({pageURL: newItemURL});
+   });
+},
+//Check if new items exists
+checkItemExists : function(XWModalContent){
+   $(".checkItemExists").click(function(event){
+   var checkURL = "$xwiki.getURL('XWiki.SuggestDisplayEditItems','view','xpage=plain&amp;outputSyntax=plain&amp;action=checkItemExists')";
+   var data = $(this).parents().eq(2).serialize();
+   checkURL = checkURL + "&amp;" + data;
+   if($.trim($("#docName").val()) == ""){
+      new XWiki.widgets.Notification("$services.localization.render('xe.totem.inputmustnotbeempty')", 'error',{timeout:1});
+   }
+   else
+   {
+     new XWiki.widgets.Notification("Saving", 'inprogress');
+     $.ajax({
+      url:checkURL,
+      dataType: 'json',
+      success:function(rep, textStatus, jqXHR){
+         if(rep){ 
+             if(rep.results == false){
+                new XWiki.widgets.Notification("The target document already exists. Please choose a different name!", 'error',{timeout:1});
+             }
+             else
+             {
+                 //Load item edit file
+                 var editNewItemFormURL = rep.results + "&amp;xpage=plain";
+                 $(XWModalContent).load(editNewItemFormURL, function(){
+                     var saveURL = editNewItemFormURL.replace('/edit/','/save/');
+                     var inputs = ' &lt;input class="btn btn-primary" type="button" name="action_save" title="Alt+Shift+S" value="Save"&gt;';
+                     inputs += ' &lt;input class="btn btn-default" type="button" name="action_cancel" title="Alt+C" value="Cancel"&gt;';
+                     inputs += '&lt;input type="hidden" name="form_token" value="$!{services.csrf.getToken()}" /&gt;';
+                     inputs += '&lt;input type="hidden" name="xredirect" value="" /&gt;';
+                     $(this).html('&lt;form action="' + saveURL + '" id="editItemForm"&gt;' + $(this).html() + inputs + '&lt;/form&gt;');
+                     $.initializeItemEditForm(editNewItemFormURL,XWModalContent);
+                 });
+             }
+         }
+      },
+      complete:function(event, XMLHttpRequest, ajaxOptions){
+        //ToDo
+        $(".xnotification-inprogress").remove();    
+      },
+      error:function(jqXHR, textStatus, errorThrown)
+      {
+        //ToDo
+      }
+     });
+    }
+   });
+},
+//Method to intialize the item edit form
+initializeItemEditForm : function(itemEditURL,XWModalContent){
+   $(".xdialog-box").addClass("xwmlrg");
+   //Initialize attachment-picker fields
+   $(".attachment-picker-start").click(function(event){
+      var attPickerURL = $(this).attr("href") + "&amp;xpage=plain";
+      $.initializeAttachmentPicker(itemEditURL,attPickerURL,XWModalContent);
+      event.preventDefault();
+   });
+   //Initialize textarea fields Wysiwyg
+   Wysiwyg.onModuleLoad(function() {
+   $("textarea").each(function(){
+      var wysiwygConfig = {
+         hookId:$(this).attr("id"),
+      };
+      new WysiwygEditor(wysiwygConfig); 
+   });
+   });
+    //Initialize date picker fields : TODO
+    //Intialize save button
+    $("#editItemForm input[name='action_save']").click(function(event){
+       $.saveSuggestDisplayItem(XWModalContent);
+       event.preventDefault();
+    });
+    //Intialize cancel button
+    $("#editItemForm input[name='action_cancel']").click(function(event){
+       $(".xdialog-close").click();
+       event.preventDefault();
+    });
+},
+//Method to intialize the attachment picker after loading it
+initializeAttachmentPicker : function(itemEditURL,attPickerURL,XWModalContent){
+ $(XWModalContent).addClass("ajaxloader");
+ $(XWModalContent).load(attPickerURL,function(){
+ $(XWModalContent).removeClass("ajaxloader");
+   //Initialize attachment picker btns
+   $("input[name='action_upload'][type='submit']").click(function(event){
+      //Check input file filed
+      if($("#attachfile").val() == ""){//Empty field
+           new XWiki.widgets.Notification("$services.localization.render('xe.attachmentSelector.upload.error.noFile')", 'error');
+      }
+      else
+      {
+           //Check allowed extensions
+           var allowedExts = $("#attachfile").attr("title");
+           allowedExts = (allowedExts != "") ? allowedExts.split(', ') : new Array();
+           var fileExt = null;
+           var filename = $("#attachfile").val();
+           var fpath = filename.replace('\\', '/');
+           var pieces = fpath.split('/');
+           if(pieces.length &gt; 0){
+               var basename = pieces[pieces.length-1];
+               pieces = basename.split('.');
+               fileExt = pieces[pieces.length-1].toLowerCase();
+           }
+           if(fileExt &amp;&amp; allowedExts.indexOf(fileExt) == -1){
+               new XWiki.widgets.Notification("$services.localization.render('xe.attachmentSelector.upload.error.badExtension')", 'error');
+           }
+           else{
+               var uploadURL = $("#uploadAttachment").attr('action');
+               var params = $("#uploadAttachment :not(input[name='xredirect'])").serialize();
+               var xredirect = "$util.encodeURI($xwiki.getURL('XWiki.SuggestDisplayEditItems','view','xpage=plain&amp;outputSyntax=plain&amp;action=ajaxUploadAttachment'))";
+               uploadURL = uploadURL + "?" + params + "&amp;xredirect=" + xredirect;
+               new XWiki.widgets.Notification("$services.localization.render('xe.attachmentSelector.upload.inProgress')", 'inprogress');
+               jQuery.ajaxFileUpload({
+                  url:uploadURL,
+	          secureuri:false,
+   	          fileElementId:'attachfile',
+	          success: function (data, status){
+                  },
+                  complete:function(data, status){
+                      //Reload the page after upload
+                      $(".xnotification-inprogress").remove();
+                      $.initializeAttachmentPicker(itemEditURL,attPickerURL,XWModalContent);
+                  },
+                  error: function (data, status, e){
+	          }
+               });
+             }  
+           }
+           event.preventDefault();
+        });
+        //Initialize delete attachment btns
+        $("a.delete").click(function(event){
+            var rep = confirm("$services.localization.render('core.viewers.attachments.delete.confirm')");
+            if(rep){
+               var deleteURL = $(this).attr("href");
+               var attElem =  $(this).parents().eq(3);
+               new XWiki.widgets.Notification("$services.localization.render('core.viewers.attachments.delete.inProgress')",'inprogress');
+               $.ajax({
+	          url:deleteURL,
+		  type:'POST',
+		  complete:function(event, XMLHttpRequest, ajaxOptions){
+                     $(".xnotification-inprogress").remove();
+                     new XWiki.widgets.Notification("$services.localization.render('core.viewers.attachments.delete.done')","done");
+                     attElem.remove();
+                  }
+	       });
+             }
+            event.preventDefault();
+        });
+        //Initialize select attachment btns
+        $("a.select").click(function(event){
+            var selectURL = $(this).attr("href");
+            new XWiki.widgets.Notification("Selecting",'inprogress');
+            $.ajax({
+	       url:selectURL,
+	       type:'POST',
+	       complete:function(event, XMLHttpRequest, ajaxOptions){
+                  $(".xnotification-inprogress").remove();
+                  new XWiki.widgets.Notification("Attachment selected","done");
+                  //Reload form with selected image modal
+                  $(XWModalContent).load(itemEditURL,function(){
+                     $.initializeItemEditForm(itemEditURL,XWModalContent);
+                  });
+               }
+	    });
+            event.preventDefault();
+        });
+        //Initialize attachment picker close button
+        $("#attachment-picker-close").click(function(event){
+           //Reload edit item form
+           $(XWModalContent).load(itemEditURL,function(){
+              $.initializeItemEditForm(itemEditURL,XWModalContent);
+           });
+           event.preventDefault();
+        });
+    });
+},
+//Save sugggest display item
+saveSuggestDisplayItem : function(XWModalContent){
+   var saveURL = $("#editItemForm").attr("action");
+   var formData = $("#editItemForm").serializeObject();
+   $.ajax({
+	url:saveURL,
+	type:'POST',
+	data:(formData),
+	success:function(rep, textStatus, jqXHR){
+	},
+	complete:function(event, XMLHttpRequest, ajaxOptions){
+          //Close the XWiki Modal
+          $(".xdialog-close").click();
+        }
+    });
+}
+});
+$.initializeNewEntryBtn();
+});</code>
+    </property>
+    <property>
+      <name>Edit suggest display items</name>
+    </property>
+    <property>
+      <parse>1</parse>
+    </property>
+    <property>
+      <use>onDemand</use>
+    </property>
+  </object>
+  <object>
+    <class>
+      <name>XWiki.StyleSheetExtension</name>
+      <customClass/>
+      <customMapping/>
+      <defaultViewSheet/>
+      <defaultEditSheet/>
+      <defaultWeb/>
+      <nameField/>
+      <validationScript/>
+      <cache>
+        <cache>0</cache>
+        <disabled>0</disabled>
+        <displayType>select</displayType>
+        <multiSelect>0</multiSelect>
+        <name>cache</name>
+        <number>5</number>
+        <prettyName>Caching policy</prettyName>
+        <relationalStorage>0</relationalStorage>
+        <separator> </separator>
+        <separators> ,|</separators>
+        <size>1</size>
+        <unmodifiable>0</unmodifiable>
+        <values>long|short|default|forbid</values>
+        <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
+      </cache>
+      <code>
+        <disabled>0</disabled>
+        <name>code</name>
+        <number>2</number>
+        <prettyName>Code</prettyName>
+        <rows>20</rows>
+        <size>50</size>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.TextAreaClass</classType>
+      </code>
+      <contentType>
+        <cache>0</cache>
+        <disabled>0</disabled>
+        <displayType>select</displayType>
+        <multiSelect>0</multiSelect>
+        <name>contentType</name>
+        <number>6</number>
+        <prettyName>Content Type</prettyName>
+        <relationalStorage>0</relationalStorage>
+        <separator> </separator>
+        <separators> ,|</separators>
+        <size>1</size>
+        <unmodifiable>0</unmodifiable>
+        <values>CSS|LESS</values>
+        <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
+      </contentType>
+      <name>
+        <disabled>0</disabled>
+        <name>name</name>
+        <number>1</number>
+        <prettyName>Name</prettyName>
+        <size>30</size>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
+      </name>
+      <parse>
+        <disabled>0</disabled>
+        <displayFormType>select</displayFormType>
+        <displayType>yesno</displayType>
+        <name>parse</name>
+        <number>4</number>
+        <prettyName>Parse content</prettyName>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.BooleanClass</classType>
+      </parse>
+      <use>
+        <cache>0</cache>
+        <disabled>0</disabled>
+        <displayType>select</displayType>
+        <multiSelect>0</multiSelect>
+        <name>use</name>
+        <number>3</number>
+        <prettyName>Use this extension</prettyName>
+        <relationalStorage>0</relationalStorage>
+        <separator> </separator>
+        <separators> ,|</separators>
+        <size>1</size>
+        <unmodifiable>0</unmodifiable>
+        <values>currentPage|onDemand|always</values>
+        <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
+      </use>
+    </class>
+    <name>XWiki.SuggestDisplayEditItems</name>
+    <number>0</number>
+    <className>XWiki.StyleSheetExtension</className>
+    <guid>b6e2cfa8-bcc4-41c1-9d1f-6242a6c5cb4c</guid>
+    <property>
+      <cache>long</cache>
+    </property>
+    <property>
+      <code>.xwmlrg{
+   width:90%;
+}
+.ajaxloader{
+   background-image: url("/mainwiki/resources/icons/xwiki/ajax-loader-large.gif");
+   background-repeat: no-repeat;
+   background-position: center;
+   height: 100px
+}
+
+.ajaxloader div{
+   display:none;
+}
+.newEntryBtn{
+   margin: 0 5px;
+}</code>
+    </property>
+    <property>
+      <contentType>CSS</contentType>
+    </property>
+    <property>
+      <name>XWiki Modal Popup CSS</name>
+    </property>
+    <property>
+      <parse/>
+    </property>
+    <property>
+      <use>onDemand</use>
+    </property>
+  </object>
+  <content>{{velocity}}
+#**
+* Get item className from hibernate query
+*#
+#macro(getItemClassName $className $propertyName)
+   #set($itemClassName = "")
+   #set($p = $xwiki.getDocument($className).getxWikiClass().get($propertyName).getPropertyClass())
+   #set($hibquery = "$!p.getSql()")
+   #set($clsStartIndex = $hibquery.toLowerCase().indexOf(".classname='"))
+   #set($q1 = $hibquery.substring($mathtool.add($clsStartIndex,12)))
+   #set($clsEndIndex = $q1.toLowerCase().indexOf("'"))
+   #set($itemClassName = $q1.substring(0,$clsEndIndex))
+#end
+#set($action = $request.action)
+#if("$!action" != "")
+   #if($action == "editItem" &amp;&amp; "$!request.itemDocRef" != "" &amp;&amp; $xwiki.exists("$request.itemDocRef") &amp;&amp; "$!request.className" != "" &amp;&amp; "$!request.propertyName" != "")
+       #set($className = $request.className)
+       #set($propertyName = $request.propertyName)
+       #getItemClassName($className,$propertyName)
+       #set($itemDocRef = $request.itemDocRef)
+       #set($doc = $xwiki.getDocument($itemDocRef))
+        #if($itemClassName != "" &amp;&amp; $xwiki.exists($itemClassName))
+          #set($itemClassSheet = $itemClassName.substring(0,$itemClassName.indexOf('Class')))
+          #set($itemClassSheet = "${itemClassSheet}Sheet")
+          {{html wiki="true"}}
+          &lt;form action="$xwiki.getURL($itemDocRef,'save')" id="editItemForm"&gt;
+            {{include document="$itemClassSheet"/}}
+             &lt;input type="hidden" name="form_token" value="$!{services.csrf.getToken()}" /&gt;
+             &lt;input type="hidden" name="xredirect" value="" /&gt;
+             &lt;input class="btn btn-primary" type="button" name="action_save" title="Alt+Shift+S" value="Save"&gt;
+             &lt;input class="btn btn-default" type="button" name="action_cancel" title="Alt+C" value="Cancel"&gt;
+          &lt;/form&gt;
+          {{/html}}
+       #else
+          ##TODO
+       #end
+   #elseif($action == "newItem" &amp;&amp; "$!request.className" != "" &amp;&amp; "$!request.propertyName" != "" &amp;&amp; "$!request.parent" != "" &amp;&amp; "$!request.space" != "")
+       #set($className = $request.className)
+       #set($propertyName = $request.propertyName)
+       #set($parent = $request.parent)
+       #set($space = $request.space)
+       #getItemClassName($className,$propertyName)
+       #if($itemClassName != "" &amp;&amp; $xwiki.exists($itemClassName))
+          #set($itemClassTemplate = $itemClassName.substring(0,$itemClassName.indexOf('Class')))
+          #set($itemClassTemplate = "${itemClassTemplate}Template")
+       #else
+          ##TODO
+       #end
+
+       {{html}}
+         &lt;form action="" id="newdoc" method="post"&gt;
+            &lt;div&gt;
+              &lt;input type="hidden" name="form_token" value="$!{services.csrf.getToken()}" /&gt;
+              &lt;input type="hidden" name="parent" value="${parent}"/&gt;
+              &lt;input type="hidden" name="template" value="${itemClassTemplate}"/&gt;
+              &lt;input type="hidden" name="sheet" value="1"/&gt;
+              &lt;label for="spaceName"&gt;Space: &lt;/label&gt;&lt;input type="text" id="spaceName" name="spaceName" value="${space}" size="8"/&gt;
+              &lt;label for="docName"&gt;Document: &lt;/label&gt;&lt;input type="text" id="docName" name="docName" value="" class="withTip"'/&gt;         
+              &lt;span class="buttonwrapper"&gt;&lt;input type="button" value="Create this document" class="button checkItemExists"/&gt;&lt;/span&gt;
+            &lt;/div&gt;
+          &lt;/form&gt;
+        {{/html}}
+   #elseif($action == "checkItemExists" &amp;&amp; "$!request.spaceName" != "" &amp;&amp; "$!request.docName" != "")
+      #set($itemRef = "${request.spaceName}.${request.docName}")
+      #if($xwiki.exists($itemRef))
+           {"results":false}
+      #else
+         #set($documentReference = $services.model.createDocumentReference(null, $request.spaceName, $request.docName))
+         #set($redirectURL = $xwiki.getURL($documentReference,'edit',"template=${request.template}&amp;parent=${request.parent}&amp;title=${request.docName}"))
+           {"results":"$redirectURL"}
+        #end
+   #elseif($action == "ajaxUploadAttachment")
+       {"results":true}
+   #end
+#end
+{{/velocity}}</content>
+</xwikidoc>

--- a/src/main/resources/XWiki/SuggestDisplayEditItems.xml
+++ b/src/main/resources/XWiki/SuggestDisplayEditItems.xml
@@ -128,7 +128,7 @@ if(typeof(XWiki) == "undefined" || typeof(XWiki.widgets) == "undefined" || typeo
   }
 } else {
 
-XWiki.widgets.MyModalPopup = Class.create(XWiki.widgets.ModalPopup, {
+XWiki.widgets.EditModePopup = Class.create(XWiki.widgets.ModalPopup, {
  /** Default parameters can be added to the custom class. */
   defaultInteractionParameters : {
   },
@@ -576,7 +576,7 @@ initializeNewEntryBtn : function(){
       var newItemURL = "$xwiki.getURL("XWiki.SuggestDisplayEditItems",'edit','editor=inline&amp;xpage=plain')";
       newItemURL = newItemURL + '&amp;action=newItem' + "&amp;className=" + className + "&amp;propertyName=" + propertyName + "&amp;parent=" + itemParent + "&amp;space=" + itemSpace;
       $('.xdialog-modal-container').remove();
-      new XWiki.widgets.MyModalPopup({pageURL: newItemURL});
+      new XWiki.widgets.EditModePopup({pageURL: newItemURL});
    });
 },
 //Check if new items exists

--- a/src/main/resources/XWiki/SuggestDisplayEditItems.xml
+++ b/src/main/resources/XWiki/SuggestDisplayEditItems.xml
@@ -564,28 +564,28 @@ $.fn.serializeObject = function()
 };
 
 $.extend({
-//Method to initialize the new item btn
-initializeNewEntryBtn : function(){
-   $("body").on("click",".newEntryBtn",function(event){
+// Method to initialize the new item btn
+initializeNewEntryBtn : function() {
+   $("body").on("click",".newEntryBtn",function(event) {
       var index = $(".newEntryBtn").index($(this));
       var className = $("input[type='hidden'][id$='_className']").eq(index).val();
       var propertyName = $("input[type='hidden'][id$='_propertyName']").eq(index).val();
       var itemParent = $("#itemParent").eq(0).val();
       var itemSpace = $("#itemSpace").eq(0).val();
-      //Open XWiki Modal
+      // Open XWiki Modal
       var newItemURL = "$xwiki.getURL("XWiki.SuggestDisplayEditItems",'view','xpage=plain')";
       newItemURL = newItemURL + '&amp;action=newItem' + "&amp;className=" + className + "&amp;propertyName=" + propertyName + "&amp;parent=" + itemParent + "&amp;space=" + itemSpace;
       $('.xdialog-modal-container').remove();
       new XWiki.widgets.EditModePopup({pageURL: newItemURL});
    });
 },
-//Check if new items exists
-checkItemExists : function(XWModalContent){
-   $(".checkItemExists").click(function(event){
+// Check if new items exists
+checkItemExists : function(XWModalContent) {
+   $(".checkItemExists").click(function(event) {
    var checkURL = "$xwiki.getURL('XWiki.SuggestDisplayEditItems','view','xpage=plain&amp;outputSyntax=plain&amp;action=checkItemExists')";
    var data = $(this).parents().eq(2).serialize();
    checkURL = checkURL + "&amp;" + data;
-   if($.trim($("#docName").val()) == ""){
+   if ($.trim($("#docName").val()) == "") {
       new XWiki.widgets.Notification("$services.localization.render('xe.totem.inputmustnotbeempty')", 'error',{timeout:1});
    }
    else
@@ -594,16 +594,16 @@ checkItemExists : function(XWModalContent){
      $.ajax({
       url:checkURL,
       dataType: 'json',
-      success:function(rep, textStatus, jqXHR){
-         if(rep){ 
-             if(rep.results == false){
+      success: function(rep, textStatus, jqXHR) {
+         if (rep) { 
+             if (rep.results == false) {
                 new XWiki.widgets.Notification("The target document already exists. Please choose a different name!", 'error',{timeout:1});
              }
              else
              {
-                 //Load item edit file
+                 // Load item edit file
                  var editNewItemFormURL = rep.results + "&amp;xpage=plain";
-                 $(XWModalContent).load(editNewItemFormURL, function(){
+                 $(XWModalContent).load(editNewItemFormURL, function() {
                      var saveURL = editNewItemFormURL.replace('/edit/','/save/');
                      var inputs = ' &lt;input class="btn btn-primary" type="button" name="action_save" title="Alt+Shift+S" value="Save"&gt;';
                      inputs += ' &lt;input class="btn btn-default" type="button" name="action_cancel" title="Alt+C" value="Cancel"&gt;';
@@ -615,38 +615,37 @@ checkItemExists : function(XWModalContent){
              }
          }
       },
-      complete:function(event, XMLHttpRequest, ajaxOptions){
-        //ToDo
+      complete: function(event, XMLHttpRequest, ajaxOptions) {
+        // ToDo
         $(".xnotification-inprogress").remove();    
       },
-      error:function(jqXHR, textStatus, errorThrown)
-      {
-        //ToDo
+      error: function(jqXHR, textStatus, errorThrown) {
+        // ToDo
       }
      });
     }
    });
 },
-//Method to intialize the item edit form
-initializeItemEditForm : function(itemEditURL,XWModalContent){
+// Method to intialize the item edit form
+initializeItemEditForm : function(itemEditURL,XWModalContent) {
    $(".xdialog-box").addClass("xwmlrg");
-   //Initialize attachment-picker fields
-   $(".attachment-picker-start").click(function(event){
+   // Initialize attachment-picker fields
+   $(".attachment-picker-start").click(function(event) {
       var attPickerURL = $(this).attr("href") + "&amp;xpage=plain";
       var wikiName = $("#wikiName").val();
       attPickerURL = attPickerURL + "&amp;wikiName=" + wikiName;
-      if(attPickerURL.indexOf('docname=' + wikiName + ":") == -1){
+      if (attPickerURL.indexOf('docname=' + wikiName + ":") == -1) {
          attPickerURL = attPickerURL.replace('docname=','docname=' + wikiName + ':');
       }
       $.initializeAttachmentPicker(itemEditURL,attPickerURL,XWModalContent);
       event.preventDefault();
    });
-   //Initialize textarea fields Wysiwyg
+   // Initialize textarea fields Wysiwyg
    #set($wysiwygConfig = {})
    #wysiwyg_storeConfig($wysiwygConfig $doc "HOOKID" true)
    #set($jsVarName = "wysiwygConfig${util.generateRandomString(4)}")
    Wysiwyg.onModuleLoad(function() {
-   $("textarea").each(function(){
+   $("textarea").each(function() {
       var wysiwygConfig = {
          #set($separator = '')
          #foreach($entry in $wysiwygConfig.entrySet())
@@ -661,27 +660,27 @@ initializeItemEditForm : function(itemEditURL,XWModalContent){
       new WysiwygEditor(wysiwygConfig); 
    });
    });
-    //Initialize date picker fields : TODO
-    //Intialize save button
-    $("#editItemForm input[name='action_save']").click(function(event){
+    // Initialize date picker fields : TODO
+    // Intialize save button
+    $("#editItemForm input[name='action_save']").click(function(event) {
        $.saveSuggestDisplayItem(XWModalContent);
        event.preventDefault();
     });
-    //Intialize cancel button
-    $("#editItemForm input[name='action_cancel']").click(function(event){
+    // Intialize cancel button
+    $("#editItemForm input[name='action_cancel']").click(function(event) {
        $(".xdialog-close").click();
        event.preventDefault();
     });
 },
-//Method to intialize the attachment picker after loading it
-initializeAttachmentPicker : function(itemEditURL,attPickerURL,XWModalContent){
+// Method to intialize the attachment picker after loading it
+initializeAttachmentPicker : function(itemEditURL,attPickerURL,XWModalContent) {
  $(XWModalContent).addClass("ajaxloader");
- $(XWModalContent).load(attPickerURL,function(){
+ $(XWModalContent).load(attPickerURL,function() {
  $(XWModalContent).removeClass("ajaxloader");
    //Initialize attachment picker btns
-   $("input[name='action_upload'][type='submit']").click(function(event){
-      //Check input file filed
-      if($("#attachfile").val() == ""){//Empty field
+   $("input[name='action_upload'][type='submit']").click(function(event) {
+      // Check input file filed
+      if ($("#attachfile").val() == "") {// Empty field
            new XWiki.widgets.Notification("$services.localization.render('xe.attachmentSelector.upload.error.noFile')", 'error');
       }
       else
@@ -693,12 +692,12 @@ initializeAttachmentPicker : function(itemEditURL,attPickerURL,XWModalContent){
            var filename = $("#attachfile").val();
            var fpath = filename.replace('\\', '/');
            var pieces = fpath.split('/');
-           if(pieces.length &gt; 0){
+           if (pieces.length &gt; 0) {
                var basename = pieces[pieces.length-1];
                pieces = basename.split('.');
                fileExt = pieces[pieces.length-1].toLowerCase();
            }
-           if(fileExt &amp;&amp; allowedExts.indexOf(fileExt) == -1){
+           if(fileExt &amp;&amp; allowedExts.indexOf(fileExt) == -1) {
                new XWiki.widgets.Notification("$services.localization.render('xe.attachmentSelector.upload.error.badExtension')", 'error');
            }
            else{
@@ -708,34 +707,34 @@ initializeAttachmentPicker : function(itemEditURL,attPickerURL,XWModalContent){
                uploadURL = uploadURL + "?" + params + "&amp;xredirect=" + xredirect;
                new XWiki.widgets.Notification("$services.localization.render('xe.attachmentSelector.upload.inProgress')", 'inprogress');
                jQuery.ajaxFileUpload({
-                  url:uploadURL,
-	          secureuri:false,
-   	          fileElementId:'attachfile',
-	          success: function (data, status){
+                  url: uploadURL,
+	          secureuri: false,
+   	          fileElementId: 'attachfile',
+	          success: function (data, status) {
                   },
-                  complete:function(data, status){
-                      //Reload the page after upload
+                  complete: function(data, status) {
+                      // Reload the page after upload
                       $(".xnotification-inprogress").remove();
                       $.initializeAttachmentPicker(itemEditURL,attPickerURL,XWModalContent);
                   },
-                  error: function (data, status, e){
+                  error: function (data, status, e) {
 	          }
                });
              }  
            }
            event.preventDefault();
         });
-        //Initialize delete attachment btns
-        $("a.delete").click(function(event){
+        // Initialize delete attachment btns
+        $("a.delete").click(function(event) {
             var rep = confirm("$services.localization.render('core.viewers.attachments.delete.confirm')");
-            if(rep){
+            if(rep) {
                var deleteURL = $(this).attr("href");
                var attElem =  $(this).parents().eq(3);
                new XWiki.widgets.Notification("$services.localization.render('core.viewers.attachments.delete.inProgress')",'inprogress');
                $.ajax({
-	          url:deleteURL,
-		  type:'POST',
-		  complete:function(event, XMLHttpRequest, ajaxOptions){
+	          url: deleteURL,
+		  type: 'POST',
+		  complete: function(event, XMLHttpRequest, ajaxOptions) {
                      $(".xnotification-inprogress").remove();
                      new XWiki.widgets.Notification("$services.localization.render('core.viewers.attachments.delete.done')","done");
                      attElem.remove();
@@ -744,17 +743,17 @@ initializeAttachmentPicker : function(itemEditURL,attPickerURL,XWModalContent){
              }
             event.preventDefault();
         });
-        //Initialize select attachment btns
-        $("a.select").click(function(event){
+        // Initialize select attachment btns
+        $("a.select").click(function(event) {
             var selectURL = $(this).attr("href");
             new XWiki.widgets.Notification("Selecting",'inprogress');
             $.ajax({
 	       url:selectURL,
 	       type:'POST',
-	       complete:function(event, XMLHttpRequest, ajaxOptions){
+	       complete: function(event, XMLHttpRequest, ajaxOptions) {
                   $(".xnotification-inprogress").remove();
                   new XWiki.widgets.Notification("Attachment selected","done");
-                  //Reload form with selected image modal
+                  // Reload form with selected image modal
                   $(XWModalContent).load(itemEditURL,function(){
                      $.initializeItemEditForm(itemEditURL,XWModalContent);
                   });
@@ -762,27 +761,27 @@ initializeAttachmentPicker : function(itemEditURL,attPickerURL,XWModalContent){
 	    });
             event.preventDefault();
         });
-        //Initialize attachment picker close button
-        $("#attachment-picker-close").click(function(event){
-           //Reload edit item form
-           $(XWModalContent).load(itemEditURL,function(){
+        // Initialize attachment picker close button
+        $("#attachment-picker-close").click(function(event) {
+           // Reload edit item form
+           $(XWModalContent).load(itemEditURL,function() {
               $.initializeItemEditForm(itemEditURL,XWModalContent);
            });
            event.preventDefault();
         });
     });
 },
-//Save sugggest display item
-saveSuggestDisplayItem : function(XWModalContent){
+// Save sugggest display item
+saveSuggestDisplayItem : function(XWModalContent) {
    var saveURL = $("#editItemForm").attr("action");
    var formData = $("#editItemForm").serialize();
    $.ajax({
 	url:saveURL + "?" + formData,
 	type:'GET',
-	success:function(rep, textStatus, jqXHR){
+	success:function(rep, textStatus, jqXHR) {
 	},
-	complete:function(event, XMLHttpRequest, ajaxOptions){
-          //Close the XWiki Modal
+	complete:function(event, XMLHttpRequest, ajaxOptions) {
+          // Close the XWiki Modal
           $(".xdialog-close").click();
         }
     });

--- a/src/main/resources/XWiki/SuggestDisplayEditItems.xml
+++ b/src/main/resources/XWiki/SuggestDisplayEditItems.xml
@@ -267,7 +267,6 @@ XWiki.widgets.MyModalPopup = Class.create(XWiki.widgets.ModalPopup, {
     </property>
     <property>
       <code>require(['jquery'],function($){
-//var j = $.noConflict();
 $.extend({
 	createUploadIframe: function(id, uri){
 		//create frame

--- a/src/main/resources/XWiki/SuggestDisplayEditItems.xml
+++ b/src/main/resources/XWiki/SuggestDisplayEditItems.xml
@@ -269,7 +269,7 @@ XWiki.widgets.EditModePopup = Class.create(XWiki.widgets.ModalPopup, {
       <code>document.observe('xwiki:dom:loading', function() {
 // Configure require.js to use jquery-form (https://github.com/malsup/form)
 require.config({
-   "paths": { "jquery-form": "$services.webjars.url('jquery-form/3.52-SNAPSHOT/jquery.form.js')" },
+   "paths": { "jquery-form": "$services.webjars.url('jquery-form/3.51/jquery.form.js')" },
    "shim": { "jquery-form": [ "jquery" ] }
     });
 });</code>

--- a/src/main/resources/XWiki/SuggestDisplayEditItems.xml
+++ b/src/main/resources/XWiki/SuggestDisplayEditItems.xml
@@ -61,7 +61,7 @@
         <prettyName>Caching policy</prettyName>
         <relationalStorage>0</relationalStorage>
         <separator> </separator>
-        <separators> ,|</separators>
+        <separators>|, </separators>
         <size>1</size>
         <unmodifiable>0</unmodifiable>
         <values>long|short|default|forbid</values>
@@ -106,7 +106,7 @@
         <prettyName>Use this extension</prettyName>
         <relationalStorage>0</relationalStorage>
         <separator> </separator>
-        <separators> ,|</separators>
+        <separators>|, </separators>
         <size>1</size>
         <unmodifiable>0</unmodifiable>
         <values>currentPage|onDemand|always</values>
@@ -206,7 +206,7 @@ XWiki.widgets.EditModePopup = Class.create(XWiki.widgets.ModalPopup, {
         <prettyName>Caching policy</prettyName>
         <relationalStorage>0</relationalStorage>
         <separator> </separator>
-        <separators> ,|</separators>
+        <separators>|, </separators>
         <size>1</size>
         <unmodifiable>0</unmodifiable>
         <values>long|short|default|forbid</values>
@@ -251,7 +251,7 @@ XWiki.widgets.EditModePopup = Class.create(XWiki.widgets.ModalPopup, {
         <prettyName>Use this extension</prettyName>
         <relationalStorage>0</relationalStorage>
         <separator> </separator>
-        <separators> ,|</separators>
+        <separators>|, </separators>
         <size>1</size>
         <unmodifiable>0</unmodifiable>
         <values>currentPage|onDemand|always</values>
@@ -485,7 +485,7 @@ handleError: function( s, xhr, status, e ) {
         <prettyName>Caching policy</prettyName>
         <relationalStorage>0</relationalStorage>
         <separator> </separator>
-        <separators> ,|</separators>
+        <separators>|, </separators>
         <size>1</size>
         <unmodifiable>0</unmodifiable>
         <values>long|short|default|forbid</values>
@@ -530,7 +530,7 @@ handleError: function( s, xhr, status, e ) {
         <prettyName>Use this extension</prettyName>
         <relationalStorage>0</relationalStorage>
         <separator> </separator>
-        <separators> ,|</separators>
+        <separators>|, </separators>
         <size>1</size>
         <unmodifiable>0</unmodifiable>
         <values>currentPage|onDemand|always</values>
@@ -573,7 +573,7 @@ initializeNewEntryBtn : function(){
       var itemParent = $("#itemParent").eq(0).val();
       var itemSpace = $("#itemSpace").eq(0).val();
       //Open XWiki Modal
-      var newItemURL = "$xwiki.getURL("XWiki.SuggestDisplayEditItems",'edit','editor=inline&amp;xpage=plain')";
+      var newItemURL = "$xwiki.getURL("XWiki.SuggestDisplayEditItems",'view','xpage=plain')";
       newItemURL = newItemURL + '&amp;action=newItem' + "&amp;className=" + className + "&amp;propertyName=" + propertyName + "&amp;parent=" + itemParent + "&amp;space=" + itemSpace;
       $('.xdialog-modal-container').remove();
       new XWiki.widgets.EditModePopup({pageURL: newItemURL});
@@ -652,6 +652,7 @@ initializeItemEditForm : function(itemEditURL,XWModalContent){
          #end
       };
       wysiwygConfig.hookId = $(this).attr("id");
+      wysiwygConfig.inputURL = wysiwygConfig.inputURL.replace('/edit/','/view/');
       new WysiwygEditor(wysiwygConfig); 
    });
    });
@@ -815,7 +816,7 @@ $.initializeNewEntryBtn();
         <prettyName>Caching policy</prettyName>
         <relationalStorage>0</relationalStorage>
         <separator> </separator>
-        <separators> ,|</separators>
+        <separators>|, </separators>
         <size>1</size>
         <unmodifiable>0</unmodifiable>
         <values>long|short|default|forbid</values>
@@ -841,7 +842,7 @@ $.initializeNewEntryBtn();
         <prettyName>Content Type</prettyName>
         <relationalStorage>0</relationalStorage>
         <separator> </separator>
-        <separators> ,|</separators>
+        <separators>|, </separators>
         <size>1</size>
         <unmodifiable>0</unmodifiable>
         <values>CSS|LESS</values>
@@ -876,7 +877,7 @@ $.initializeNewEntryBtn();
         <prettyName>Use this extension</prettyName>
         <relationalStorage>0</relationalStorage>
         <separator> </separator>
-        <separators> ,|</separators>
+        <separators>|, </separators>
         <size>1</size>
         <unmodifiable>0</unmodifiable>
         <values>currentPage|onDemand|always</values>
@@ -937,17 +938,25 @@ $.initializeNewEntryBtn();
 #set($action = $request.action)
 #if("$!action" != "")
    #if($action == "editItem" &amp;&amp; "$!request.itemDocRef" != "" &amp;&amp; $xwiki.exists("$request.itemDocRef") &amp;&amp; "$!request.className" != "" &amp;&amp; "$!request.propertyName" != "")
+     #set($itemDocRef = $request.itemDocRef)
+     #if($xwiki.hasAccessLevel('edit',$xcontext.user,${itemDocRef}))
+       #set($discard = $context.setDisplayMode("edit"))
        #set($className = $request.className)
        #set($propertyName = $request.propertyName)
        #getItemClassName($className,$propertyName)
-       #set($itemDocRef = $request.itemDocRef)
        #set($doc = $xwiki.getDocument($itemDocRef))
-        #if($itemClassName != "" &amp;&amp; $xwiki.exists($itemClassName))
+       #if($itemClassName != "" &amp;&amp; $xwiki.exists($itemClassName))
           #set($itemClassSheet = $itemClassName.substring(0,$itemClassName.indexOf('Class')))
           #set($itemClassSheet = "${itemClassSheet}Sheet")
+          ## To show the edit attachment button of the attachment selector we need to check 
+          ## if the current user has edit rights on the item document and then set the $hasEdit variable to true 
+          #set($itemEditPerm = $xwiki.hasAccessLevel('edit',$xcontext.user,${itemDocRef}))
+          #if($itemEditPerm &amp;&amp; !$hasEdit)
+             #set($hasEdit = true)
+          #end
           {{html wiki="true"}}
           &lt;form action="$xwiki.getURL($itemDocRef,'save')" id="editItemForm"&gt;
-            {{include document="$itemClassSheet"/}}
+            {{include reference="$itemClassSheet"/}}
              &lt;input type="hidden" name="form_token" value="$!{services.csrf.getToken()}" /&gt;
              &lt;input type="hidden" name="xredirect" value="" /&gt;
              &lt;input class="btn btn-primary" type="button" name="action_save" title="Alt+Shift+S" value="Save"&gt;
@@ -957,6 +966,11 @@ $.initializeNewEntryBtn();
        #else
           ##TODO
        #end
+     #else
+
+        {{error}}$services.localization.render('error') : $services.localization.render('notallowed'){{/error}}
+
+     #end 
    #elseif($action == "newItem" &amp;&amp; "$!request.className" != "" &amp;&amp; "$!request.propertyName" != "" &amp;&amp; "$!request.parent" != "" &amp;&amp; "$!request.space" != "")
        #set($className = $request.className)
        #set($propertyName = $request.propertyName)
@@ -969,7 +983,6 @@ $.initializeNewEntryBtn();
        #else
           ##TODO
        #end
-
        {{html}}
          &lt;form action="" id="newdoc" method="post"&gt;
             &lt;div&gt;

--- a/src/main/resources/XWiki/SuggestDisplayEditItems.xml
+++ b/src/main/resources/XWiki/SuggestDisplayEditItems.xml
@@ -266,12 +266,10 @@ XWiki.widgets.EditModePopup = Class.create(XWiki.widgets.ModalPopup, {
       <cache>long</cache>
     </property>
     <property>
-      <code>document.observe('xwiki:dom:loading', function() {
-// Configure require.js to use jquery-form (https://github.com/malsup/form)
+      <code>// Configure require.js to use jquery-form (https://github.com/malsup/form)
 require.config({
    "paths": { "jquery-form": "$services.webjars.url('jquery-form/3.51/jquery.form.js')" },
    "shim": { "jquery-form": [ "jquery" ] }
-    });
 });</code>
     </property>
     <property>

--- a/src/main/resources/XWiki/SuggestDisplayEditItems.xml
+++ b/src/main/resources/XWiki/SuggestDisplayEditItems.xml
@@ -266,7 +266,12 @@ XWiki.widgets.EditModePopup = Class.create(XWiki.widgets.ModalPopup, {
       <cache>long</cache>
     </property>
     <property>
-      <code>require(['jquery'],function($){
+      <code>/**
+*   jQuery Ajax File Uploader Version 2.1
+*   jQuery plugin for file upload (http://www.phpletter.com/Our-Projects/AjaxFileUpload/)
+*/
+
+require(['jquery'],function($){
 $.extend({
 	createUploadIframe: function(id, uri){
 		//create frame
@@ -900,7 +905,7 @@ $.initializeNewEntryBtn();
    width:90%;
 }
 .ajaxloader{
-   background-image: url("/mainwiki/resources/icons/xwiki/ajax-loader-large.gif");
+   background-image: url("$xwiki.getSkinFile('icons/xwiki/ajax-loader-large.gif')");
    background-repeat: no-repeat;
    background-position: center;
    height: 100px
@@ -920,7 +925,7 @@ $.initializeNewEntryBtn();
       <name>XWiki Modal Popup CSS</name>
     </property>
     <property>
-      <parse/>
+      <parse>1</parse>
     </property>
     <property>
       <use>onDemand</use>

--- a/src/main/resources/XWiki/SuggestDisplayEditItems.xml
+++ b/src/main/resources/XWiki/SuggestDisplayEditItems.xml
@@ -801,9 +801,9 @@ $.initializeNewEntryBtn();
            {"results":false}
       #else
          #set($documentReference = $services.model.createDocumentReference(null, $request.spaceName, $request.docName))
-         #set($title = $util.encodeURI($request.docName))
-         #set($parent = $util.encodeURI($request.parent))
-         #set($template = $util.encodeURI($request.template))
+         #set($title = $escapetool.url($request.docName))
+         #set($parent = $escapetool.url($request.parent))
+         #set($template = $escapetool.url($request.template))
          #set($redirectURL = $xwiki.getURL($documentReference,'edit',"template=${template}&amp;parent=${parent}&amp;title=${title}"))
            {"results":"$redirectURL"}
         #end

--- a/src/main/resources/XWiki/SuggestDisplayEditItems.xml
+++ b/src/main/resources/XWiki/SuggestDisplayEditItems.xml
@@ -365,23 +365,6 @@ require.config({
     </property>
     <property>
       <code>require(['jquery'],function($){
-$.fn.serializeObject = function()
-{
-    var o = {};
-    var a = this.serializeArray();
-    $.each(a, function() {
-        if (o[this.name] !== undefined) {
-            if (!o[this.name].push) {
-                o[this.name] = [o[this.name]];
-            }
-            o[this.name].push(this.value || '');
-        } else {
-            o[this.name] = this.value || '';
-        }
-    });
-    return o;
-};
-
 $.extend({
 // Method to initialize the new item btn
 initializeNewEntryBtn : function() {


### PR DESCRIPTION
The itemsEditable mode allows you to create new items and edit selected items in the displayer-multiselect-suggest.
The edition or creation of items is done in popus.

In this PR I make the following modifications :
- Add an edit button to the selected items ( add the editItem method in the XWiki.SuggestDisplay javascriptExtension).
- Add a new entry button next to the displayer-multiselect-suggest input (add the insertNewEntryBt() method in the XWiki.SuggestDisplay javascriptExtension).
- Modify the  velocity code of XWiki.SuggestDisplay document to integrate the ItemsEditable mode
- Add a new document XWiki.SuggestDisplayEditItems that contains the whole code of the ItemsEditable mode.
- Notice that the use of the ItemsEditable mode is on demande, then there is  no impact on the normal use of displayer-multiselect-suggest if the itemsEditable mode is not activated.
